### PR TITLE
[Issue #55] Claude Code 환경에서 빈 문자열 env var로 인한 빌드 실패 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,27 @@
+import fs from 'fs'
+import path from 'path'
 import type { NextConfig } from 'next'
 import { validateEnv } from './src/lib/env'
+
+// Claude Code 등 일부 환경에서 ANTHROPIC_API_KEY='' (빈 문자열)을 child process에 주입한다.
+// Next.js의 @next/env는 빈 문자열도 "이미 정의됨"으로 간주해 .env.local 값을 스킵하므로,
+// validateEnv() 호출 전에 빈 문자열 env var를 .env.local 값으로 복원한다.
+const envLocalPath = path.join(process.cwd(), '.env.local')
+if (fs.existsSync(envLocalPath)) {
+  const lines = fs.readFileSync(envLocalPath, 'utf-8').split('\n')
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const eqIdx = trimmed.indexOf('=')
+    if (eqIdx === -1) continue
+    const key = trimmed.slice(0, eqIdx).trim()
+    const raw = trimmed.slice(eqIdx + 1).trim()
+    const value = raw.startsWith('"') && raw.endsWith('"') ? raw.slice(1, -1) : raw
+    if (process.env[key] === '') {
+      process.env[key] = value
+    }
+  }
+}
 
 // 빌드/시작 시 환경변수 검증 — 누락 시 명확한 오류로 즉시 종료
 try {


### PR DESCRIPTION
## Summary

- `next.config.ts`에서 `validateEnv()` 호출 전, `.env.local`을 직접 파싱하여 빈 문자열(`''`)인 env var만 복원하도록 처리
- Claude Code가 `ANTHROPIC_API_KEY=''`를 child process에 주입 → Next.js `@next/env`가 빈 문자열을 "이미 정의됨"으로 판단해 `.env.local` 값을 스킵 → `validateEnv()` 실패 → 빌드 중단 문제를 해결

## Test plan

- [x] `ANTHROPIC_API_KEY='' npm run build` 실행 → 빌드 성공 확인 (이전에는 실패)
- [x] `npm run validate` (type-check): 통과
- [x] `npm run build` (`ANTHROPIC_API_KEY=''` 주입 시뮬레이션): 성공

### validate
```
> tsc --noEmit  → exit 0
```

### test
해당 없음 (next.config.ts 로직은 빌드 시점 전용, unit test 불가)

### build
```
ANTHROPIC_API_KEY='' npm run build → 빌드 성공
```

Closes #55