### PR TITLE
[Issue #17] 피드 카드 렌더러 구현

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,7 +1,9 @@
+import FeedDisclaimer from '@/components/features/feed/FeedDisclaimer'
+
 export default function PublicLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="mx-auto min-h-screen max-w-[960px]">
-      {/* TODO(#24): 투자 자문 아님 고지 배너 */}
+      <FeedDisclaimer />
       <main>{children}</main>
     </div>
   )

--- a/src/components/features/feed/FeedCardStack.tsx
+++ b/src/components/features/feed/FeedCardStack.tsx
@@ -1,0 +1,151 @@
+import type { CSSProperties } from 'react'
+
+import FeedSourceLink from '@/components/features/feed/FeedSourceLink'
+import type { Card, CardSource } from '@/types/cards'
+
+type FeedCardStackProps = {
+  cards: Card[] | null
+}
+
+function cardStyle(card: Card): CSSProperties {
+  return {
+    backgroundImage: `linear-gradient(160deg, ${card.visual.bg_from} 0%, ${card.visual.bg_via} 55%, ${card.visual.bg_to} 100%)`,
+    borderColor: `${card.visual.accent}55`,
+    boxShadow: `inset 0 1px 0 rgba(255,255,255,0.08), 0 18px 40px rgba(15, 23, 42, 0.25)`,
+  }
+}
+
+function sectionLabel(card: Card, index: number, total: number) {
+  return `${index + 1}/${total} · ${card.tag}`
+}
+
+function SourceList({
+  sources,
+  emptyLabel = '출처 확인 중',
+}: {
+  sources: CardSource[]
+  emptyLabel?: string
+}) {
+  if (sources.length === 0) {
+    return <p className="text-muted text-xs">{emptyLabel}</p>
+  }
+
+  return (
+    <div className="mt-4 flex flex-wrap gap-2">
+      {sources.map((source) => (
+        <FeedSourceLink key={`${source.domain}-${source.url}`} source={source} />
+      ))}
+    </div>
+  )
+}
+
+function CardBody({ card }: { card: Card }) {
+  switch (card.type) {
+    case 'cover':
+      return (
+        <>
+          <h3 className="text-2xl leading-tight font-bold whitespace-pre-line">{card.title}</h3>
+          <p className="text-foreground/80 text-sm whitespace-pre-line">{card.sub}</p>
+        </>
+      )
+    case 'reason':
+    case 'bullish':
+    case 'bearish':
+      return (
+        <>
+          <h3 className="text-xl leading-tight font-semibold whitespace-pre-line">{card.title}</h3>
+          <p className="text-foreground/85 text-sm leading-6 whitespace-pre-line">{card.body}</p>
+          {card.stat ? (
+            <p className="inline-flex rounded-full bg-white/10 px-3 py-1 text-xs font-semibold">
+              {card.stat}
+            </p>
+          ) : null}
+          <SourceList sources={card.sources} />
+        </>
+      )
+    case 'community':
+      return (
+        <>
+          <h3 className="text-xl leading-tight font-semibold whitespace-pre-line">{card.title}</h3>
+          <div className="space-y-3">
+            {card.quotes.map((quote, index) => (
+              <blockquote
+                key={`${quote.text}-${index}`}
+                className="rounded-2xl bg-white/8 px-4 py-3 text-sm leading-6"
+              >
+                <p>{quote.text}</p>
+                <footer className="text-foreground/65 mt-2 text-xs">{quote.mood}</footer>
+              </blockquote>
+            ))}
+          </div>
+        </>
+      )
+    case 'stats':
+      return (
+        <>
+          <h3 className="text-xl leading-tight font-semibold whitespace-pre-line">{card.title}</h3>
+          <dl className="grid gap-3 sm:grid-cols-2">
+            {card.items.map((item) => (
+              <div key={`${item.label}-${item.value}`} className="rounded-2xl bg-white/8 px-4 py-3">
+                <dt className="text-foreground/65 text-xs">{item.label}</dt>
+                <dd className="mt-1 text-lg font-semibold">{item.value}</dd>
+                {item.change ? (
+                  <dd className="text-foreground/80 mt-1 text-xs">{item.change}</dd>
+                ) : null}
+              </div>
+            ))}
+          </dl>
+        </>
+      )
+    case 'source':
+      return (
+        <>
+          <h3 className="text-xl leading-tight font-semibold">출처 전체 보기</h3>
+          <p className="text-foreground/80 text-sm leading-6">
+            아래 링크에서 원문을 확인할 수 있습니다.
+          </p>
+          <SourceList
+            sources={card.sources}
+            emptyLabel="출처가 아직 연결되지 않았습니다. 운영 화면에서 보완이 필요합니다."
+          />
+        </>
+      )
+  }
+}
+
+export default function FeedCardStack({ cards }: FeedCardStackProps) {
+  if (!cards || cards.length === 0) {
+    return (
+      <div className="border-border bg-surface/60 rounded-[28px] border p-5">
+        <p className="text-foreground text-sm font-semibold">카드 데이터를 준비 중입니다.</p>
+        <p className="text-muted mt-2 text-sm">운영 검수 후 이 이슈의 카드 스트림이 표시됩니다.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {cards.map((card, index) => (
+        <article
+          key={card.id}
+          className="overflow-hidden rounded-[28px] border px-5 py-5 text-white sm:px-6 sm:py-6"
+          style={cardStyle(card)}
+        >
+          <div className="space-y-5">
+            <div className="flex items-center justify-between gap-3">
+              <p className="rounded-full bg-white/12 px-3 py-1 text-[11px] font-semibold tracking-[0.18em] uppercase">
+                {sectionLabel(card, index, cards.length)}
+              </p>
+              <p className="text-[11px] font-medium tracking-[0.14em] text-white/70 uppercase">
+                {card.type}
+              </p>
+            </div>
+            <div className="space-y-4">
+              <CardBody card={card} />
+            </div>
+          </div>
+        </article>
+      ))}
+    </div>
+  )
+}

--- a/src/components/features/feed/FeedDisclaimer.tsx
+++ b/src/components/features/feed/FeedDisclaimer.tsx
@@ -1,0 +1,10 @@
+export default function FeedDisclaimer() {
+  return (
+    <aside className="border-border bg-surface/70 mx-4 mt-4 rounded-2xl border px-4 py-3">
+      <p className="text-foreground text-sm font-semibold">
+        본 콘텐츠는 투자 자문이 아닌 정보 제공 목적입니다.
+      </p>
+      <p className="text-muted mt-1 text-xs">투자 판단과 책임은 이용자 본인에게 있습니다.</p>
+    </aside>
+  )
+}

--- a/src/components/features/feed/FeedSourceLink.tsx
+++ b/src/components/features/feed/FeedSourceLink.tsx
@@ -1,0 +1,37 @@
+import type { CardSource } from '@/types/cards'
+
+type FeedSourceLinkProps = {
+  source: CardSource
+}
+
+function isSafeExternalUrl(url: string) {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:'
+  } catch {
+    return false
+  }
+}
+
+export default function FeedSourceLink({ source }: FeedSourceLinkProps) {
+  if (!isSafeExternalUrl(source.url)) {
+    return (
+      <span className="border-border bg-background/25 inline-flex min-h-11 items-center rounded-full border px-3 py-2 text-left">
+        <span className="text-foreground text-xs font-medium">{source.domain}</span>
+        <span className="text-muted ml-2 text-xs">링크 확인 필요</span>
+      </span>
+    )
+  }
+
+  return (
+    <a
+      href={source.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="border-border bg-background/25 hover:bg-background/40 inline-flex min-h-11 items-center rounded-full border px-3 py-2 text-left transition-colors"
+    >
+      <span className="text-foreground text-xs font-medium">{source.domain}</span>
+      <span className="text-muted ml-2 text-xs">{source.title}</span>
+    </a>
+  )
+}

--- a/src/components/features/feed/FeedView.tsx
+++ b/src/components/features/feed/FeedView.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-// TODO(#17): 카드 렌더러 구현 시 실제 카드 UI로 교체
 // TODO(#18): 스와이프 UI 구현 시 스와이프 탐색 추가
 
 import type { PublicIssueSummary } from '@/lib/public/feeds'
+
+import FeedCardStack from './FeedCardStack'
 
 type FeedViewProps = {
   date: string
@@ -13,43 +14,59 @@ type FeedViewProps = {
 
 export default function FeedView({ date, issues, initialIssueId }: FeedViewProps) {
   return (
-    <div className="flex min-h-screen flex-col">
-      <header className="border-border border-b px-4 py-3">
+    <div className="flex min-h-screen flex-col pb-10">
+      <header className="border-border border-b px-4 py-4">
         <p className="text-muted text-sm">{date}</p>
-        <p className="text-foreground text-xs">이슈 {issues.length}건</p>
+        <div className="mt-2 flex items-end justify-between gap-4">
+          <div>
+            <h1 className="text-foreground text-xl font-semibold">오늘의 이슈 카드 스트림</h1>
+            <p className="text-muted mt-1 text-sm">이슈 {issues.length}건</p>
+          </div>
+          <p className="text-muted max-w-44 text-right text-xs leading-5">
+            사건, 해석, 시장 반응 흐름으로 정리한 카드 브리핑
+          </p>
+        </div>
       </header>
-      <main className="flex flex-1 flex-col gap-4 p-4">
+      <main className="flex flex-1 flex-col gap-5 p-4">
         {issues.map((issue) => (
-          <div
+          <section
             key={issue.id}
             data-issue-id={issue.id}
             className={[
-              'bg-surface rounded-xl p-4',
-              initialIssueId === issue.id ? 'ring-accent-blue ring-2' : '',
+              'border-border rounded-[32px] border bg-white/3 p-4 shadow-[0_18px_40px_rgba(2,6,23,0.18)] backdrop-blur-sm',
+              initialIssueId === issue.id
+                ? 'ring-accent-blue ring-2 ring-offset-2 ring-offset-slate-950'
+                : '',
             ]
               .join(' ')
               .trim()}
           >
-            <div className="flex items-start justify-between gap-2">
-              <div className="flex flex-col gap-1">
-                <div className="flex flex-wrap gap-1">
+            <div className="mb-4 flex items-start justify-between gap-4">
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap gap-2">
+                  <span className="bg-background/70 text-muted rounded-full px-3 py-1 text-[11px] font-semibold tracking-[0.16em] uppercase">
+                    {issue.entityType}
+                  </span>
                   {issue.tags.map((tag) => (
                     <span
                       key={tag}
-                      className="bg-surface-raised text-muted rounded px-2 py-0.5 text-xs"
+                      className="bg-surface-raised text-muted rounded-full px-3 py-1 text-xs"
                     >
                       {tag}
                     </span>
                   ))}
                 </div>
-                <h2 className="text-foreground text-sm leading-snug font-semibold">
+                <h2 className="text-foreground mt-3 text-xl leading-snug font-semibold">
                   {issue.title}
                 </h2>
+                <p className="text-muted mt-2 text-sm">
+                  {issue.entityName} · 카드 {issue.cardsData?.length ?? 0}장
+                </p>
               </div>
               {issue.changeValue && (
                 <span
                   className={[
-                    'shrink-0 text-sm font-bold',
+                    'shrink-0 rounded-full px-3 py-1 text-sm font-bold',
                     issue.changeValue.startsWith('-') ? 'text-accent-red' : 'text-accent-green',
                   ].join(' ')}
                 >
@@ -57,7 +74,8 @@ export default function FeedView({ date, issues, initialIssueId }: FeedViewProps
                 </span>
               )}
             </div>
-          </div>
+            <FeedCardStack cards={issue.cardsData} />
+          </section>
         ))}
       </main>
     </div>

--- a/tests/unit/components/FeedView.test.tsx
+++ b/tests/unit/components/FeedView.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import FeedDisclaimer from '@/components/features/feed/FeedDisclaimer'
+import FeedView from '@/components/features/feed/FeedView'
+import type { PublicIssueSummary } from '@/lib/public/feeds'
+
+const sampleIssue: PublicIssueSummary = {
+  id: 'issue-1',
+  entityType: 'stock',
+  entityId: '005930',
+  entityName: '삼성전자',
+  title: '삼성전자 급등',
+  changeValue: '+3.2%',
+  channel: 'v1',
+  displayOrder: 1,
+  tags: ['반도체', '실적'],
+  cardsData: [
+    {
+      id: 1,
+      type: 'cover',
+      tag: '속보',
+      title: '삼성전자\n오늘 최고 +3.2%',
+      sub: '외국인 순매수 확대',
+      visual: {
+        bg_from: '#0f172a',
+        bg_via: '#1e3a5f',
+        bg_to: '#0f172a',
+        accent: '#3B82F6',
+      },
+    },
+    {
+      id: 2,
+      type: 'reason',
+      tag: '원인',
+      title: '메모리 업황 기대',
+      body: '엔비디아 실적 이후 AI 밸류체인 기대가 확대됐습니다.',
+      stat: '외국인 순매수 +3,200억',
+      visual: {
+        bg_from: '#0f172a',
+        bg_via: '#052e16',
+        bg_to: '#0f172a',
+        accent: '#22C55E',
+      },
+      sources: [
+        {
+          title: '관련 기사',
+          url: 'https://example.com/article',
+          domain: 'example.com',
+        },
+      ],
+    },
+    {
+      id: 3,
+      type: 'source',
+      tag: '출처',
+      sources: [
+        {
+          title: '원문 보기',
+          url: 'https://example.com/source',
+          domain: 'example.com',
+        },
+      ],
+      visual: {
+        bg_from: '#0f172a',
+        bg_via: '#1e293b',
+        bg_to: '#0f172a',
+        accent: '#94A3B8',
+      },
+    },
+  ],
+}
+
+describe('FeedView', () => {
+  it('카드 타입별 UI와 출처 링크를 렌더링한다', () => {
+    render(<FeedView date="2026-03-20" issues={[sampleIssue]} />)
+
+    expect(screen.getByText('오늘의 이슈 카드 스트림')).toBeInTheDocument()
+    expect(screen.getByText('메모리 업황 기대')).toBeInTheDocument()
+    expect(screen.getByText('외국인 순매수 +3,200억')).toBeInTheDocument()
+    expect(screen.getByText('출처 전체 보기')).toBeInTheDocument()
+
+    const link = screen.getAllByRole('link', { name: /example.com/i })[0]
+    expect(link).toHaveAttribute('href', 'https://example.com/article')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('cardsData가 없으면 fallback 안내를 렌더링한다', () => {
+    render(
+      <FeedView
+        date="2026-03-20"
+        issues={[
+          {
+            ...sampleIssue,
+            id: 'issue-2',
+            title: '카드 없음',
+            cardsData: null,
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('카드 데이터를 준비 중입니다.')).toBeInTheDocument()
+  })
+
+  it('잘못된 출처 URL은 클릭 가능한 링크 대신 fallback 문구를 렌더링한다', () => {
+    const invalidReasonCard = {
+      id: 2,
+      type: 'reason' as const,
+      tag: '원인',
+      title: '메모리 업황 기대',
+      body: '엔비디아 실적 이후 AI 밸류체인 기대가 확대됐습니다.',
+      stat: '외국인 순매수 +3,200억',
+      visual: {
+        bg_from: '#0f172a',
+        bg_via: '#052e16',
+        bg_to: '#0f172a',
+        accent: '#22C55E',
+      },
+      sources: [
+        {
+          title: 'broken',
+          url: 'javascript:alert(1)',
+          domain: 'bad.example',
+        },
+      ],
+    }
+
+    render(
+      <FeedView
+        date="2026-03-20"
+        issues={[
+          {
+            ...sampleIssue,
+            id: 'issue-3',
+            cardsData: [sampleIssue.cardsData![0], invalidReasonCard, sampleIssue.cardsData![2]],
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('링크 확인 필요')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /bad\.example/i })).not.toBeInTheDocument()
+  })
+})
+
+describe('FeedDisclaimer', () => {
+  it('투자 자문 아님 고지를 렌더링한다', () => {
+    render(<FeedDisclaimer />)
+
+    expect(
+      screen.getByText('본 콘텐츠는 투자 자문이 아닌 정보 제공 목적입니다.'),
+    ).toBeInTheDocument()
+    expect(screen.getByText('투자 판단과 책임은 이용자 본인에게 있습니다.')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- 공개 피드 목록을 단순 텍스트 리스트 대신 cards_data 기반 카드 스트림으로 렌더링하도록 변경했습니다.
- 투자 자문 아님 고지 배너를 공개 피드/공유 랜딩 공통 레이아웃에 추가했습니다.
- 출처 링크를 카드 내부에서 노출하고, 외부 링크 보안 속성과 잘못된 URL fallback을 적용했습니다.

## Test plan
- `npm run validate` ✅
- `npm run test` ✅
- `npm run build` ✅ (`metadataBase` 미설정 경고만 확인, 빌드 성공)

Closes #17
