### PR TITLE
[Issue #19] 대표 맥락 카드 노출 구현

### DIFF
--- a/src/components/features/feed/FeedView.tsx
+++ b/src/components/features/feed/FeedView.tsx
@@ -2,7 +2,9 @@
 
 // TODO(#18): 스와이프 UI 구현 시 스와이프 탐색 추가
 
+import FeedSourceLink from '@/components/features/feed/FeedSourceLink'
 import type { PublicIssueSummary } from '@/lib/public/feeds'
+import type { CardSource } from '@/types/cards'
 
 import FeedCardStack from './FeedCardStack'
 
@@ -12,7 +14,68 @@ type FeedViewProps = {
   initialIssueId?: string
 }
 
+const CONTEXT_SLOTS = [
+  { entityId: 'KOSPI', entityName: '코스피', entityType: 'index' as const },
+  { entityId: 'NASDAQ', entityName: '나스닥', entityType: 'index' as const },
+  { entityId: 'USD-KRW', entityName: 'USD/KRW', entityType: 'fx' as const },
+] as const
+
+function getContextSummary(issue: PublicIssueSummary | null): {
+  summary: string
+  source: CardSource | null
+} {
+  if (!issue?.cardsData || issue.cardsData.length === 0) {
+    return {
+      summary: '당일 변동 요약을 준비 중입니다. 데이터 수급이 완료되면 업데이트됩니다.',
+      source: null,
+    }
+  }
+
+  const explanationCard = issue.cardsData.find(
+    (card) =>
+      card.type === 'reason' ||
+      card.type === 'bullish' ||
+      card.type === 'bearish' ||
+      card.type === 'cover',
+  )
+
+  if (!explanationCard) {
+    return {
+      summary: '당일 변동 요약을 준비 중입니다. 데이터 수급이 완료되면 업데이트됩니다.',
+      source: null,
+    }
+  }
+
+  if (explanationCard.type === 'cover') {
+    return {
+      summary: explanationCard.sub ?? '당일 변동 요약을 준비 중입니다.',
+      source: null,
+    }
+  }
+
+  return {
+    summary: explanationCard.body,
+    source: explanationCard.sources[0] ?? null,
+  }
+}
+
 export default function FeedView({ date, issues, initialIssueId }: FeedViewProps) {
+  const contextIssues = CONTEXT_SLOTS.map((slot) => {
+    const issue =
+      issues.find((candidate) => candidate.entityId === slot.entityId) ??
+      issues.find(
+        (candidate) =>
+          candidate.entityName === slot.entityName && candidate.entityType === slot.entityType,
+      ) ??
+      null
+
+    return {
+      ...slot,
+      issue,
+      ...getContextSummary(issue),
+    }
+  })
+
   return (
     <div className="flex min-h-screen flex-col pb-10">
       <header className="border-border border-b px-4 py-4">
@@ -28,9 +91,68 @@ export default function FeedView({ date, issues, initialIssueId }: FeedViewProps
         </div>
       </header>
       <main className="flex flex-1 flex-col gap-5 p-4">
+        <section className="rounded-[32px] border border-white/10 bg-[linear-gradient(160deg,rgba(15,23,42,0.96),rgba(17,24,39,0.92),rgba(3,7,18,0.98))] p-5 shadow-[0_18px_40px_rgba(2,6,23,0.24)]">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-[11px] font-semibold tracking-[0.22em] text-cyan-200 uppercase">
+                Market Context
+              </p>
+              <h2 className="mt-2 text-xl font-semibold text-white">대표 지수·환율 맥락 카드</h2>
+            </div>
+            <p className="max-w-xl text-sm leading-6 text-slate-300">
+              코스피, 나스닥, USD/KRW 흐름을 먼저 확인하고 개별 이슈 카드로 내려가세요.
+            </p>
+          </div>
+          <div className="mt-5 grid gap-4 lg:grid-cols-3">
+            {contextIssues.map((item) => (
+              <article
+                key={item.entityId}
+                className="rounded-[28px] border border-white/12 bg-white/[0.04] p-4 text-white backdrop-blur-sm"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-[11px] font-semibold tracking-[0.2em] text-white/55 uppercase">
+                      {item.entityType}
+                    </p>
+                    <h3 className="mt-2 text-lg font-semibold">{item.entityName}</h3>
+                  </div>
+                  <span
+                    className={[
+                      'rounded-full px-3 py-1 text-sm font-bold',
+                      item.issue?.changeValue?.startsWith('-')
+                        ? 'bg-cyan-400/10 text-cyan-200'
+                        : 'bg-emerald-400/10 text-emerald-200',
+                    ].join(' ')}
+                  >
+                    {item.issue?.changeValue ?? '업데이트 지연'}
+                  </span>
+                </div>
+                <p className="mt-4 line-clamp-3 text-sm leading-6 text-slate-200">{item.summary}</p>
+                <div className="mt-4 flex flex-wrap items-center gap-2">
+                  {item.source ? (
+                    <FeedSourceLink source={item.source} />
+                  ) : (
+                    <span className="rounded-full border border-dashed border-white/15 px-3 py-2 text-xs text-white/60">
+                      출처 확인 후 업데이트
+                    </span>
+                  )}
+                  {item.issue ? (
+                    <a
+                      href={`#issue-${item.issue.id}`}
+                      className="rounded-full border border-white/12 px-3 py-2 text-xs font-medium text-white/75 transition hover:border-white/30 hover:text-white"
+                    >
+                      이슈 카드 보기
+                    </a>
+                  ) : null}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
         {issues.map((issue) => (
           <section
             key={issue.id}
+            id={`issue-${issue.id}`}
             data-issue-id={issue.id}
             className={[
               'border-border rounded-[32px] border bg-white/3 p-4 shadow-[0_18px_40px_rgba(2,6,23,0.18)] backdrop-blur-sm',

--- a/tests/unit/components/FeedView.test.tsx
+++ b/tests/unit/components/FeedView.test.tsx
@@ -71,6 +71,71 @@ const sampleIssue: PublicIssueSummary = {
   ],
 }
 
+const contextIssue: PublicIssueSummary = {
+  id: 'context-kospi',
+  entityType: 'index',
+  entityId: 'KOSPI',
+  entityName: '코스피',
+  title: '코스피 반등',
+  changeValue: '+0.47%',
+  channel: 'v1',
+  displayOrder: 0,
+  tags: ['지수'],
+  cardsData: [
+    {
+      id: 1,
+      type: 'cover',
+      tag: '맥락',
+      title: '코스피 반등',
+      sub: '+0.47% · 외국인 순매수',
+      visual: {
+        bg_from: '#001a0d',
+        bg_via: '#003320',
+        bg_to: '#005533',
+        accent: '#00c853',
+      },
+    },
+    {
+      id: 2,
+      type: 'reason',
+      tag: '이유',
+      title: '외국인 매수세 유입',
+      body: '반도체 중심으로 외국인 순매수가 유입되며 지수가 반등했습니다.',
+      visual: {
+        bg_from: '#001a0d',
+        bg_via: '#003320',
+        bg_to: '#005533',
+        accent: '#00c853',
+      },
+      sources: [
+        {
+          title: '지수 기사',
+          url: 'https://example.com/kospi',
+          domain: 'example.com',
+        },
+      ],
+    },
+    {
+      id: 3,
+      type: 'source',
+      tag: '출처',
+      sources: [
+        {
+          title: '원문',
+          url: 'https://example.com/kospi-source',
+          domain: 'example.com',
+        },
+      ],
+      visual: {
+        bg_from: '#001a0d',
+        bg_via: '#003320',
+        bg_to: '#005533',
+        accent: '#00c853',
+      },
+    },
+  ],
+}
+
 describe('FeedView', () => {
   it('카드 타입별 UI와 출처 링크를 렌더링한다', () => {
     render(<FeedView date="2026-03-20" issues={[sampleIssue]} />)
@@ -84,6 +149,18 @@ describe('FeedView', () => {
     expect(link).toHaveAttribute('href', 'https://example.com/article')
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('대표 지수·환율 맥락 섹션을 렌더링하고 누락 슬롯은 업데이트 지연으로 표시한다', () => {
+    render(<FeedView date="2026-03-20" issues={[contextIssue, sampleIssue]} />)
+
+    expect(screen.getByText('대표 지수·환율 맥락 카드')).toBeInTheDocument()
+    expect(screen.getByText('코스피')).toBeInTheDocument()
+    expect(screen.getByText('USD/KRW')).toBeInTheDocument()
+    expect(screen.getAllByText('업데이트 지연').length).toBeGreaterThan(0)
+
+    const jumpLink = screen.getByRole('link', { name: '이슈 카드 보기' })
+    expect(jumpLink).toHaveAttribute('href', '#issue-context-kospi')
   })
 
   it('cardsData가 없으면 fallback 안내를 렌더링한다', () => {


### PR DESCRIPTION
## Summary
- 공개 피드 상단에 코스피, 나스닥, USD/KRW 전용 맥락 섹션을 추가해 대표 지수/환율 흐름을 먼저 확인할 수 있게 했습니다.
- 맥락 이슈가 아직 없을 때는 `업데이트 지연` 상태와 후속 안내를 노출해 문서에 정의된 예외 흐름을 반영했습니다.
- FeedView 단위 테스트를 확장해 맥락 섹션, 누락 슬롯 fallback, 이슈 점프 링크를 검증했습니다.

## Test plan
- `npm run test -- tests/unit/components/FeedView.test.tsx` ✅
- `npm run validate` ✅
- `npm run build` ✅

Closes #19
