### PR TITLE
[Issue #22] 이슈 permalink 공유 기능 구현

### DIFF
--- a/src/app/(public)/feed/[date]/issue/[id]/page.tsx
+++ b/src/app/(public)/feed/[date]/issue/[id]/page.tsx
@@ -32,7 +32,7 @@ export async function generateMetadata({ params }: { params: Params }): Promise<
         title: issue.title,
         description,
         url: `https://findori.app/feed/${date}/issue/${id}`,
-        images: [{ url: '/og-default.png' }],
+        images: [{ url: `/api/og/issue/${id}` }],
       },
     }
   } catch {

--- a/src/components/features/feed/FeedShareButton.tsx
+++ b/src/components/features/feed/FeedShareButton.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useState } from 'react'
+
+type FeedShareButtonProps = {
+  permalink: string
+  title: string
+  summary: string
+}
+
+type ShareStatus = 'idle' | 'shared' | 'copied' | 'error'
+
+export default function FeedShareButton({ permalink, title, summary }: FeedShareButtonProps) {
+  const [status, setStatus] = useState<ShareStatus>('idle')
+
+  async function copyLink() {
+    if (!navigator.clipboard?.writeText) {
+      setStatus('error')
+      return false
+    }
+
+    await navigator.clipboard.writeText(permalink)
+    setStatus('copied')
+    return true
+  }
+
+  async function handleShare() {
+    try {
+      if (navigator.share) {
+        await navigator.share({
+          title,
+          text: summary,
+          url: permalink,
+        })
+        setStatus('shared')
+        return
+      }
+
+      await copyLink()
+    } catch {
+      try {
+        await copyLink()
+      } catch {
+        setStatus('error')
+      }
+    }
+  }
+
+  const statusMessage =
+    status === 'shared'
+      ? '공유 패널을 열었습니다.'
+      : status === 'copied'
+        ? '링크를 복사했습니다.'
+        : status === 'error'
+          ? '공유 링크를 복사하지 못했습니다.'
+          : null
+
+  return (
+    <div className="flex flex-col items-end gap-2">
+      <button
+        type="button"
+        onClick={handleShare}
+        className="min-h-11 rounded-full border border-white/12 px-4 py-2 text-sm font-medium text-white/80 transition hover:border-white/30 hover:text-white"
+      >
+        공유
+      </button>
+      {statusMessage ? (
+        <p className="text-right text-xs text-slate-300" role="status">
+          {statusMessage}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/features/feed/FeedView.tsx
+++ b/src/components/features/feed/FeedView.tsx
@@ -7,6 +7,7 @@ import type { PublicIssueSummary } from '@/lib/public/feeds'
 import type { CardSource } from '@/types/cards'
 
 import FeedCardStack from './FeedCardStack'
+import FeedShareButton from './FeedShareButton'
 
 type FeedViewProps = {
   date: string
@@ -60,6 +61,7 @@ function getContextSummary(issue: PublicIssueSummary | null): {
 }
 
 export default function FeedView({ date, issues, initialIssueId }: FeedViewProps) {
+  const origin = typeof window === 'undefined' ? 'https://findori.app' : window.location.origin
   const contextIssues = CONTEXT_SLOTS.map((slot) => {
     const issue =
       issues.find((candidate) => candidate.entityId === slot.entityId) ??
@@ -185,16 +187,23 @@ export default function FeedView({ date, issues, initialIssueId }: FeedViewProps
                   {issue.entityName} · 카드 {issue.cardsData?.length ?? 0}장
                 </p>
               </div>
-              {issue.changeValue && (
-                <span
-                  className={[
-                    'shrink-0 rounded-full px-3 py-1 text-sm font-bold',
-                    issue.changeValue.startsWith('-') ? 'text-accent-red' : 'text-accent-green',
-                  ].join(' ')}
-                >
-                  {issue.changeValue}
-                </span>
-              )}
+              <div className="flex shrink-0 flex-col items-end gap-3">
+                {issue.changeValue && (
+                  <span
+                    className={[
+                      'rounded-full px-3 py-1 text-sm font-bold',
+                      issue.changeValue.startsWith('-') ? 'text-accent-red' : 'text-accent-green',
+                    ].join(' ')}
+                  >
+                    {issue.changeValue}
+                  </span>
+                )}
+                <FeedShareButton
+                  permalink={`${origin}/feed/${date}/issue/${issue.id}`}
+                  title={issue.title}
+                  summary={`${issue.entityName} 이슈 카드 스트림`}
+                />
+              </div>
             </div>
             <FeedCardStack cards={issue.cardsData} />
           </section>

--- a/tests/unit/components/FeedShareButton.test.tsx
+++ b/tests/unit/components/FeedShareButton.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import FeedShareButton from '@/components/features/feed/FeedShareButton'
+
+const shareMock = vi.fn()
+const writeTextMock = vi.fn()
+
+describe('FeedShareButton', () => {
+  beforeEach(() => {
+    shareMock.mockReset()
+    writeTextMock.mockReset()
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { origin: 'https://findori.app' },
+    })
+
+    Object.defineProperty(navigator, 'share', {
+      configurable: true,
+      value: shareMock,
+    })
+
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: writeTextMock },
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('Web Share API가 있으면 공유 패널을 호출한다', async () => {
+    shareMock.mockResolvedValue(undefined)
+
+    render(
+      <FeedShareButton
+        permalink="https://findori.app/feed/2026-03-20/issue/issue-1"
+        title="삼성전자 급등"
+        summary="삼성전자 이슈 카드 스트림"
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '공유' }))
+
+    await waitFor(() =>
+      expect(shareMock).toHaveBeenCalledWith({
+        title: '삼성전자 급등',
+        text: '삼성전자 이슈 카드 스트림',
+        url: 'https://findori.app/feed/2026-03-20/issue/issue-1',
+      }),
+    )
+
+    expect(screen.getByRole('status')).toHaveTextContent('공유 패널을 열었습니다.')
+    expect(writeTextMock).not.toHaveBeenCalled()
+  })
+
+  it('share가 실패하면 링크 복사 fallback을 시도한다', async () => {
+    shareMock.mockRejectedValue(new Error('share failed'))
+    writeTextMock.mockResolvedValue(undefined)
+
+    render(
+      <FeedShareButton
+        permalink="https://findori.app/feed/2026-03-20/issue/issue-1"
+        title="삼성전자 급등"
+        summary="삼성전자 이슈 카드 스트림"
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '공유' }))
+
+    await waitFor(() =>
+      expect(writeTextMock).toHaveBeenCalledWith(
+        'https://findori.app/feed/2026-03-20/issue/issue-1',
+      ),
+    )
+
+    expect(screen.getByRole('status')).toHaveTextContent('링크를 복사했습니다.')
+  })
+})


### PR DESCRIPTION
## Summary
- 공개 피드에서 각 이슈 카드를 permalink 단위로 바로 공유할 수 있는 `공유` CTA를 추가했습니다.
- `navigator.share()` 실패 또는 미지원 환경에서는 클립보드 복사로 fallback 하도록 `FeedShareButton`을 분리했습니다.
- 공유 링크 metadata 이미지 경로를 이슈별 `/api/og/issue/[id]` 엔드포인트로 맞췄고, 단위 테스트로 share/fallback 동작을 검증했습니다.

## Test plan
- `npm run test -- tests/unit/components/FeedShareButton.test.tsx tests/unit/components/FeedView.test.tsx` ✅
- `npm run validate` ✅
- `npm run build` ✅

Closes #22
