### PR TITLE
[Issue #18] 스와이프 카드 탐색 UI 구현

### DIFF
--- a/src/components/features/feed/FeedCardStack.tsx
+++ b/src/components/features/feed/FeedCardStack.tsx
@@ -1,4 +1,7 @@
-import type { CSSProperties } from 'react'
+'use client'
+
+import { useRef, useState } from 'react'
+import type { CSSProperties, TouchEvent } from 'react'
 
 import FeedSourceLink from '@/components/features/feed/FeedSourceLink'
 import type { Card, CardSource } from '@/types/cards'
@@ -114,6 +117,9 @@ function CardBody({ card }: { card: Card }) {
 }
 
 export default function FeedCardStack({ cards }: FeedCardStackProps) {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const touchStartXRef = useRef<number | null>(null)
+
   if (!cards || cards.length === 0) {
     return (
       <div className="border-border bg-surface/60 rounded-[28px] border p-5">
@@ -123,29 +129,114 @@ export default function FeedCardStack({ cards }: FeedCardStackProps) {
     )
   }
 
+  const activeCard = cards[activeIndex]
+  const totalCards = cards.length
+  const progress = ((activeIndex + 1) / totalCards) * 100
+
+  function moveCard(direction: 'prev' | 'next') {
+    setActiveIndex((current) => {
+      if (direction === 'prev') {
+        return Math.max(0, current - 1)
+      }
+
+      return Math.min(totalCards - 1, current + 1)
+    })
+  }
+
+  function handleTouchStart(event: TouchEvent<HTMLDivElement>) {
+    touchStartXRef.current = event.changedTouches[0]?.clientX ?? null
+  }
+
+  function handleTouchEnd(event: TouchEvent<HTMLDivElement>) {
+    if (touchStartXRef.current === null) {
+      return
+    }
+
+    const endX = event.changedTouches[0]?.clientX ?? touchStartXRef.current
+    const deltaX = endX - touchStartXRef.current
+    touchStartXRef.current = null
+
+    if (Math.abs(deltaX) < 40) {
+      return
+    }
+
+    if (deltaX < 0) {
+      moveCard('next')
+      return
+    }
+
+    moveCard('prev')
+  }
+
   return (
     <div className="space-y-4">
-      {cards.map((card, index) => (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-muted text-xs">좌우로 넘기거나 버튼으로 카드를 이동하세요.</p>
+          <p className="text-muted text-xs font-medium">
+            {activeIndex + 1}/{totalCards}
+          </p>
+        </div>
+        <div
+          aria-hidden="true"
+          className="h-1.5 overflow-hidden rounded-full bg-white/10"
+          role="progressbar"
+          aria-valuemin={1}
+          aria-valuemax={totalCards}
+          aria-valuenow={activeIndex + 1}
+        >
+          <div
+            className="h-full rounded-full bg-white/80 transition-[width] duration-200 ease-out"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </div>
+      <div
+        data-testid="feed-card-swipe"
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+      >
         <article
-          key={card.id}
+          key={activeCard.id}
           className="overflow-hidden rounded-[28px] border px-5 py-5 text-white sm:px-6 sm:py-6"
-          style={cardStyle(card)}
+          style={cardStyle(activeCard)}
         >
           <div className="space-y-5">
             <div className="flex items-center justify-between gap-3">
               <p className="rounded-full bg-white/12 px-3 py-1 text-[11px] font-semibold tracking-[0.18em] uppercase">
-                {sectionLabel(card, index, cards.length)}
+                {sectionLabel(activeCard, activeIndex, totalCards)}
               </p>
               <p className="text-[11px] font-medium tracking-[0.14em] text-white/70 uppercase">
-                {card.type}
+                {activeCard.type}
               </p>
             </div>
             <div className="space-y-4">
-              <CardBody card={card} />
+              <CardBody card={activeCard} />
             </div>
           </div>
         </article>
-      ))}
+      </div>
+      <div className="flex items-center justify-between gap-3">
+        <button
+          type="button"
+          onClick={() => moveCard('prev')}
+          disabled={activeIndex === 0}
+          className="min-h-11 rounded-full border border-white/12 px-4 py-2 text-sm font-medium text-white/80 transition disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          이전 카드
+        </button>
+        <p className="text-muted text-xs" aria-live="polite">
+          {sectionLabel(activeCard, activeIndex, totalCards)}
+        </p>
+        <button
+          type="button"
+          onClick={() => moveCard('next')}
+          disabled={activeIndex === totalCards - 1}
+          className="min-h-11 rounded-full border border-white/12 px-4 py-2 text-sm font-medium text-white/80 transition disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          다음 카드
+        </button>
+      </div>
     </div>
   )
 }

--- a/tests/unit/components/FeedCardStack.test.tsx
+++ b/tests/unit/components/FeedCardStack.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import FeedCardStack from '@/components/features/feed/FeedCardStack'
+import type { Card } from '@/types/cards'
+
+const cards: Card[] = [
+  {
+    id: 1,
+    type: 'cover',
+    tag: '속보',
+    title: '삼성전자 급등',
+    sub: '+3.2% · 외국인 순매수',
+    visual: {
+      bg_from: '#0f172a',
+      bg_via: '#1e3a5f',
+      bg_to: '#0f172a',
+      accent: '#3B82F6',
+    },
+  },
+  {
+    id: 2,
+    type: 'reason',
+    tag: '원인',
+    title: 'AI 밸류체인 기대',
+    body: '메모리 업황 기대가 확대되며 투자 심리가 개선됐습니다.',
+    visual: {
+      bg_from: '#0f172a',
+      bg_via: '#052e16',
+      bg_to: '#0f172a',
+      accent: '#22C55E',
+    },
+    sources: [{ title: '기사', url: 'https://example.com/reason', domain: 'example.com' }],
+  },
+  {
+    id: 3,
+    type: 'source',
+    tag: '출처',
+    sources: [{ title: '원문', url: 'https://example.com/source', domain: 'example.com' }],
+    visual: {
+      bg_from: '#0f172a',
+      bg_via: '#1e293b',
+      bg_to: '#0f172a',
+      accent: '#94A3B8',
+    },
+  },
+]
+
+describe('FeedCardStack', () => {
+  it('다음/이전 버튼으로 현재 카드를 이동하고 진행 상태를 갱신한다', () => {
+    render(<FeedCardStack cards={cards} />)
+
+    expect(screen.getByText('삼성전자 급등')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '이전 카드' })).toBeDisabled()
+
+    fireEvent.click(screen.getByRole('button', { name: '다음 카드' }))
+
+    expect(screen.getByText('AI 밸류체인 기대')).toBeInTheDocument()
+    expect(screen.getAllByText('2/3 · 원인').length).toBeGreaterThan(0)
+
+    fireEvent.click(screen.getByRole('button', { name: '이전 카드' }))
+
+    expect(screen.getByText('삼성전자 급등')).toBeInTheDocument()
+  })
+
+  it('좌우 스와이프로 카드를 넘긴다', () => {
+    const { container } = render(<FeedCardStack cards={cards} />)
+    const swipeSurface = container.querySelector('[data-testid="feed-card-swipe"]')
+
+    expect(swipeSurface).not.toBeNull()
+
+    fireEvent.touchStart(swipeSurface!, {
+      changedTouches: [{ clientX: 200 }],
+    })
+    fireEvent.touchEnd(swipeSurface!, {
+      changedTouches: [{ clientX: 80 }],
+    })
+
+    expect(screen.getByText('AI 밸류체인 기대')).toBeInTheDocument()
+
+    fireEvent.touchStart(swipeSurface!, {
+      changedTouches: [{ clientX: 80 }],
+    })
+    fireEvent.touchEnd(swipeSurface!, {
+      changedTouches: [{ clientX: 180 }],
+    })
+
+    expect(screen.getByText('삼성전자 급등')).toBeInTheDocument()
+  })
+})

--- a/tests/unit/components/FeedView.test.tsx
+++ b/tests/unit/components/FeedView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
 import FeedDisclaimer from '@/components/features/feed/FeedDisclaimer'
@@ -141,14 +141,19 @@ describe('FeedView', () => {
     render(<FeedView date="2026-03-20" issues={[sampleIssue]} />)
 
     expect(screen.getByText('오늘의 이슈 카드 스트림')).toBeInTheDocument()
+    expect(screen.getByText('1/3')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '다음 카드' }))
     expect(screen.getByText('메모리 업황 기대')).toBeInTheDocument()
     expect(screen.getByText('외국인 순매수 +3,200억')).toBeInTheDocument()
-    expect(screen.getByText('출처 전체 보기')).toBeInTheDocument()
 
     const link = screen.getAllByRole('link', { name: /example.com/i })[0]
     expect(link).toHaveAttribute('href', 'https://example.com/article')
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+
+    fireEvent.click(screen.getByRole('button', { name: '다음 카드' }))
+    expect(screen.getByText('출처 전체 보기')).toBeInTheDocument()
   })
 
   it('대표 지수·환율 맥락 섹션을 렌더링하고 누락 슬롯은 업데이트 지연으로 표시한다', () => {
@@ -216,6 +221,8 @@ describe('FeedView', () => {
         ]}
       />,
     )
+
+    fireEvent.click(screen.getByRole('button', { name: '다음 카드' }))
 
     expect(screen.getByText('링크 확인 필요')).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /bad\.example/i })).not.toBeInTheDocument()


### PR DESCRIPTION
## Summary
- `FeedCardStack`를 단일 카드 캐러셀로 전환해 현재 카드만 집중해서 읽을 수 있도록 구성했습니다.
- 터치 스와이프와 이전/다음 버튼을 함께 지원하고, 상단 progress bar와 현재 위치 텍스트로 진행 상태를 표시합니다.
- 카드 탐색 동작을 `FeedCardStack` 단위 테스트로 검증하고, 기존 `FeedView` 테스트도 새 탐색 흐름에 맞게 보강했습니다.

## Test plan
- `npm run test -- tests/unit/components/FeedCardStack.test.tsx tests/unit/components/FeedView.test.tsx` ✅
- `npm run validate` ✅
- `npm run build` ✅

Closes #18
