### PR TITLE
[Issue #70] 프로덕션 metadataBase 설정 정리

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import './globals.css'
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://findori.vercel.app'),
   title: '핀도리 — 오늘의 경제 이슈',
   description: '하루 10분, 오늘 경제에서 꼭 알아야 할 이슈를 카드로 정리해드립니다.',
   openGraph: {


### PR DESCRIPTION
## Summary
- 앱 전역 metadata에 `https://findori.vercel.app` 기준 `metadataBase`를 추가했습니다.
- 피드/이슈 공유 metadata가 localhost fallback 대신 실제 프로덕션 origin을 기준으로 계산되게 했습니다.
- 빌드 시 출력되던 `metadataBase` 경고가 사라지는 것을 확인했습니다.

## Test plan
- `npm run validate` ✅
- `npm run build` ✅

Closes #70
