### PR TITLE
[Issue #20] 날짜별 조회 및 재탐색 CTA 구현

### DIFF
--- a/src/app/(public)/feed/[date]/issue/[id]/page.tsx
+++ b/src/app/(public)/feed/[date]/issue/[id]/page.tsx
@@ -3,7 +3,12 @@ import { notFound } from 'next/navigation'
 
 import FeedErrorState from '@/components/features/feed/FeedErrorState'
 import FeedView from '@/components/features/feed/FeedView'
-import { getPublicFeedByDate, getPublicIssueById, isValidDate } from '@/lib/public/feeds'
+import {
+  getPreviousPublishedDate,
+  getPublicFeedByDate,
+  getPublicIssueById,
+  isValidDate,
+} from '@/lib/public/feeds'
 
 type Params = Promise<{ date: string; id: string }>
 
@@ -62,6 +67,7 @@ export default async function IssueSharePage({ params }: { params: Params }) {
 
   // 해당 날짜 전체 피드 조회 (FeedView에 이슈 목록 전달용)
   let issues: Awaited<ReturnType<typeof getPublicFeedByDate>>['issues']
+  let previousDate: string | null = null
 
   try {
     const result = await getPublicFeedByDate(date)
@@ -71,9 +77,10 @@ export default async function IssueSharePage({ params }: { params: Params }) {
     }
 
     issues = result.issues
+    previousDate = await getPreviousPublishedDate(date)
   } catch {
     return <FeedErrorState />
   }
 
-  return <FeedView date={date} issues={issues} initialIssueId={id} />
+  return <FeedView date={date} issues={issues} initialIssueId={id} previousDate={previousDate} />
 }

--- a/src/app/(public)/feed/[date]/page.tsx
+++ b/src/app/(public)/feed/[date]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation'
 import FeedEmptyState from '@/components/features/feed/FeedEmptyState'
 import FeedErrorState from '@/components/features/feed/FeedErrorState'
 import FeedView from '@/components/features/feed/FeedView'
-import { getPublicFeedByDate, isValidDate } from '@/lib/public/feeds'
+import { getPreviousPublishedDate, getPublicFeedByDate, isValidDate } from '@/lib/public/feeds'
 
 type Params = Promise<{ date: string }>
 
@@ -37,18 +37,20 @@ export default async function FeedDatePage({ params }: { params: Params }) {
 
   let feed: { date: string } | null
   let issues: Awaited<ReturnType<typeof getPublicFeedByDate>>['issues']
+  let previousDate: string | null = null
 
   try {
     const result = await getPublicFeedByDate(date)
     feed = result.feed
     issues = result.issues
+    previousDate = await getPreviousPublishedDate(date)
   } catch {
     return <FeedErrorState />
   }
 
   if (!feed) {
-    return <FeedEmptyState date={date} />
+    return <FeedEmptyState date={date} previousDate={previousDate} />
   }
 
-  return <FeedView date={date} issues={issues} />
+  return <FeedView date={date} issues={issues} previousDate={previousDate} />
 }

--- a/src/components/features/feed/FeedEmptyState.tsx
+++ b/src/components/features/feed/FeedEmptyState.tsx
@@ -2,9 +2,10 @@ import Link from 'next/link'
 
 type FeedEmptyStateProps = {
   date?: string
+  previousDate?: string | null
 }
 
-export default function FeedEmptyState({ date }: FeedEmptyStateProps) {
+export default function FeedEmptyState({ date, previousDate }: FeedEmptyStateProps) {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-6 px-4 text-center">
       <div className="flex flex-col items-center gap-2">
@@ -18,12 +19,28 @@ export default function FeedEmptyState({ date }: FeedEmptyStateProps) {
             : '아직 발행된 이슈 카드 스트림이 없습니다.'}
         </p>
       </div>
-      <Link
-        href="/"
-        className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors"
-      >
-        홈으로 이동
-      </Link>
+      <div className="flex flex-wrap justify-center gap-3">
+        {previousDate ? (
+          <Link
+            href={`/feed/${previousDate}`}
+            className="bg-accent-blue text-foreground rounded-lg px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-80"
+          >
+            이전 발행일 보기
+          </Link>
+        ) : null}
+        <Link
+          href="/feed/latest"
+          className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors"
+        >
+          최신 피드 보기
+        </Link>
+        <Link
+          href="/"
+          className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors"
+        >
+          홈으로 이동
+        </Link>
+      </div>
     </div>
   )
 }

--- a/src/components/features/feed/FeedView.tsx
+++ b/src/components/features/feed/FeedView.tsx
@@ -2,6 +2,8 @@
 
 // TODO(#18): 스와이프 UI 구현 시 스와이프 탐색 추가
 
+import Link from 'next/link'
+
 import FeedSourceLink from '@/components/features/feed/FeedSourceLink'
 import type { PublicIssueSummary } from '@/lib/public/feeds'
 import type { CardSource } from '@/types/cards'
@@ -13,6 +15,7 @@ type FeedViewProps = {
   date: string
   issues: PublicIssueSummary[]
   initialIssueId?: string
+  previousDate?: string | null
 }
 
 const CONTEXT_SLOTS = [
@@ -60,7 +63,7 @@ function getContextSummary(issue: PublicIssueSummary | null): {
   }
 }
 
-export default function FeedView({ date, issues, initialIssueId }: FeedViewProps) {
+export default function FeedView({ date, issues, initialIssueId, previousDate }: FeedViewProps) {
   const origin = typeof window === 'undefined' ? 'https://findori.app' : window.location.origin
   const contextIssues = CONTEXT_SLOTS.map((slot) => {
     const issue =
@@ -87,9 +90,27 @@ export default function FeedView({ date, issues, initialIssueId }: FeedViewProps
             <h1 className="text-foreground text-xl font-semibold">오늘의 이슈 카드 스트림</h1>
             <p className="text-muted mt-1 text-sm">이슈 {issues.length}건</p>
           </div>
-          <p className="text-muted max-w-44 text-right text-xs leading-5">
-            사건, 해석, 시장 반응 흐름으로 정리한 카드 브리핑
-          </p>
+          <div className="flex flex-col items-end gap-2">
+            <p className="text-muted max-w-44 text-right text-xs leading-5">
+              사건, 해석, 시장 반응 흐름으로 정리한 카드 브리핑
+            </p>
+            <div className="flex flex-wrap justify-end gap-2 text-xs">
+              {previousDate ? (
+                <Link
+                  href={`/feed/${previousDate}`}
+                  className="rounded-full border border-white/12 px-3 py-1.5 text-white/75 transition hover:border-white/30 hover:text-white"
+                >
+                  이전 발행일
+                </Link>
+              ) : null}
+              <Link
+                href="/feed/latest"
+                className="rounded-full border border-white/12 px-3 py-1.5 text-white/75 transition hover:border-white/30 hover:text-white"
+              >
+                최신 피드
+              </Link>
+            </div>
+          </div>
         </div>
       </header>
       <main className="flex flex-1 flex-col gap-5 p-4">

--- a/src/lib/public/feeds.ts
+++ b/src/lib/public/feeds.ts
@@ -116,6 +116,25 @@ export async function getLatestPublishedDate(): Promise<string | null> {
   return (data as { date: string } | null)?.date ?? null
 }
 
+export async function getPreviousPublishedDate(date: string): Promise<string | null> {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase
+    .from('feeds')
+    .select('date')
+    .eq('status', 'published')
+    .lt('date', date)
+    .order('date', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`이전 feed 조회 실패: ${error.message}`)
+  }
+
+  return (data as { date: string } | null)?.date ?? null
+}
+
 /**
  * 날짜별 published 피드 + approved 이슈 목록 조회.
  * @param date 'YYYY-MM-DD' (호출 전 isValidDate로 검증 필수)

--- a/tests/unit/components/FeedEmptyState.test.tsx
+++ b/tests/unit/components/FeedEmptyState.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import FeedEmptyState from '@/components/features/feed/FeedEmptyState'
+
+describe('FeedEmptyState', () => {
+  it('이전 발행일이 있으면 재탐색 CTA를 함께 렌더링한다', () => {
+    render(<FeedEmptyState date="2026-03-20" previousDate="2026-03-19" />)
+
+    expect(screen.getByText('2026-03-20 피드가 없습니다')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '이전 발행일 보기' })).toHaveAttribute(
+      'href',
+      '/feed/2026-03-19',
+    )
+    expect(screen.getByRole('link', { name: '최신 피드 보기' })).toHaveAttribute(
+      'href',
+      '/feed/latest',
+    )
+  })
+})

--- a/tests/unit/components/FeedView.test.tsx
+++ b/tests/unit/components/FeedView.test.tsx
@@ -138,10 +138,14 @@ const contextIssue: PublicIssueSummary = {
 
 describe('FeedView', () => {
   it('카드 타입별 UI와 출처 링크를 렌더링한다', () => {
-    render(<FeedView date="2026-03-20" issues={[sampleIssue]} />)
+    render(<FeedView date="2026-03-20" issues={[sampleIssue]} previousDate="2026-03-19" />)
 
     expect(screen.getByText('오늘의 이슈 카드 스트림')).toBeInTheDocument()
     expect(screen.getByText('1/3')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '이전 발행일' })).toHaveAttribute(
+      'href',
+      '/feed/2026-03-19',
+    )
 
     fireEvent.click(screen.getByRole('button', { name: '다음 카드' }))
     expect(screen.getByText('메모리 업황 기대')).toBeInTheDocument()

--- a/tests/unit/lib/public-feeds.test.ts
+++ b/tests/unit/lib/public-feeds.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import {
   isValidDate,
   getLatestPublishedDate,
+  getPreviousPublishedDate,
   getPublicFeedByDate,
   getPublicIssueById,
   type PublicIssueSummary,
@@ -114,6 +115,44 @@ describe('getLatestPublishedDate', () => {
   it('DB 오류 시 에러를 던진다', async () => {
     setupLatestChain({ data: null, error: { message: 'connection failed' } })
     await expect(getLatestPublishedDate()).rejects.toThrow('feeds 조회 실패')
+  })
+})
+
+describe('getPreviousPublishedDate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function setupPreviousChain(result: { data: unknown; error: unknown }) {
+    mockMaybeSingle.mockResolvedValue(result)
+    mockLimit.mockReturnValue({ maybeSingle: mockMaybeSingle })
+    mockOrder.mockReturnValue({ limit: mockLimit })
+    const mockLt = vi.fn().mockReturnValue({ order: mockOrder })
+    mockEq.mockReturnValue({ lt: mockLt })
+    mockSelect.mockReturnValue({ eq: mockEq })
+    mockFrom.mockReturnValue({ select: mockSelect })
+  }
+
+  it('현재 날짜보다 이전의 최신 published 날짜를 반환한다', async () => {
+    setupPreviousChain({ data: { date: '2026-03-19' }, error: null })
+
+    const result = await getPreviousPublishedDate('2026-03-20')
+
+    expect(result).toBe('2026-03-19')
+  })
+
+  it('이전 published 피드가 없으면 null을 반환한다', async () => {
+    setupPreviousChain({ data: null, error: null })
+
+    const result = await getPreviousPublishedDate('2026-03-20')
+
+    expect(result).toBeNull()
+  })
+
+  it('DB 오류 시 에러를 던진다', async () => {
+    setupPreviousChain({ data: null, error: { message: 'connection failed' } })
+
+    await expect(getPreviousPublishedDate('2026-03-20')).rejects.toThrow('이전 feed 조회 실패')
   })
 })
 


### PR DESCRIPTION
## Summary
- 날짜별 피드 페이지와 공유 페이지에서 이전 발행일을 찾아 이동할 수 있는 재탐색 CTA를 추가했습니다.
- 빈 상태 화면에서 `이전 발행일 보기`, `최신 피드 보기`, `홈으로 이동` 경로를 함께 제공하도록 확장했습니다.
- 공개 피드 데이터 계층에 `getPreviousPublishedDate()`를 추가하고 관련 단위 테스트를 보강했습니다.

## Test plan
- `npm run test -- tests/unit/lib/public-feeds.test.ts tests/unit/components/FeedEmptyState.test.tsx tests/unit/components/FeedView.test.tsx` ✅
- `npm run validate` ✅
- `npm run build` ✅

Closes #20
