### PR TITLE
[Issue #29] 공개 피드 이벤트 계측 구현

### DIFF
--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+
+import type { FeedEventPayload } from '@/lib/analytics'
+
+function isValidEvent(payload: unknown): payload is FeedEventPayload {
+  if (!payload || typeof payload !== 'object') {
+    return false
+  }
+
+  const event = (payload as { event?: unknown }).event
+  return (
+    event === 'feed_opened' ||
+    event === 'card_swiped' ||
+    event === 'share_clicked' ||
+    event === 'source_clicked'
+  )
+}
+
+export async function POST(request: Request) {
+  let payload: unknown
+
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+
+  if (!isValidEvent(payload)) {
+    return NextResponse.json({ error: 'invalid_event' }, { status: 400 })
+  }
+
+  console.info('[feed-event]', payload)
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/components/features/feed/FeedCardStack.tsx
+++ b/src/components/features/feed/FeedCardStack.tsx
@@ -3,11 +3,14 @@
 import { useRef, useState } from 'react'
 import type { CSSProperties, TouchEvent } from 'react'
 
+import { trackFeedEvent } from '@/lib/analytics'
 import FeedSourceLink from '@/components/features/feed/FeedSourceLink'
 import type { Card, CardSource } from '@/types/cards'
 
 type FeedCardStackProps = {
   cards: Card[] | null
+  entityType?: string
+  entityId?: string
 }
 
 function cardStyle(card: Card): CSSProperties {
@@ -25,9 +28,11 @@ function sectionLabel(card: Card, index: number, total: number) {
 function SourceList({
   sources,
   emptyLabel = '출처 확인 중',
+  onSourceClick,
 }: {
   sources: CardSource[]
   emptyLabel?: string
+  onSourceClick?: (source: CardSource) => void
 }) {
   if (sources.length === 0) {
     return <p className="text-muted text-xs">{emptyLabel}</p>
@@ -36,13 +41,23 @@ function SourceList({
   return (
     <div className="mt-4 flex flex-wrap gap-2">
       {sources.map((source) => (
-        <FeedSourceLink key={`${source.domain}-${source.url}`} source={source} />
+        <FeedSourceLink
+          key={`${source.domain}-${source.url}`}
+          source={source}
+          onClick={() => onSourceClick?.(source)}
+        />
       ))}
     </div>
   )
 }
 
-function CardBody({ card }: { card: Card }) {
+function CardBody({
+  card,
+  onSourceClick,
+}: {
+  card: Card
+  onSourceClick?: (source: CardSource) => void
+}) {
   switch (card.type) {
     case 'cover':
       return (
@@ -63,7 +78,7 @@ function CardBody({ card }: { card: Card }) {
               {card.stat}
             </p>
           ) : null}
-          <SourceList sources={card.sources} />
+          <SourceList sources={card.sources} onSourceClick={onSourceClick} />
         </>
       )
     case 'community':
@@ -110,13 +125,14 @@ function CardBody({ card }: { card: Card }) {
           <SourceList
             sources={card.sources}
             emptyLabel="출처가 아직 연결되지 않았습니다. 운영 화면에서 보완이 필요합니다."
+            onSourceClick={onSourceClick}
           />
         </>
       )
   }
 }
 
-export default function FeedCardStack({ cards }: FeedCardStackProps) {
+export default function FeedCardStack({ cards, entityType, entityId }: FeedCardStackProps) {
   const [activeIndex, setActiveIndex] = useState(0)
   const touchStartXRef = useRef<number | null>(null)
 
@@ -135,11 +151,33 @@ export default function FeedCardStack({ cards }: FeedCardStackProps) {
 
   function moveCard(direction: 'prev' | 'next') {
     setActiveIndex((current) => {
-      if (direction === 'prev') {
-        return Math.max(0, current - 1)
+      const nextIndex =
+        direction === 'prev' ? Math.max(0, current - 1) : Math.min(totalCards - 1, current + 1)
+
+      if (nextIndex !== current) {
+        trackFeedEvent({
+          event: 'card_swiped',
+          entityType,
+          entityId,
+          cardIndex: nextIndex + 1,
+          totalCards,
+          isLoggedIn: false,
+        })
       }
 
-      return Math.min(totalCards - 1, current + 1)
+      return nextIndex
+    })
+  }
+
+  function handleSourceClick(source: CardSource) {
+    trackFeedEvent({
+      event: 'source_clicked',
+      entityType,
+      entityId,
+      cardIndex: activeIndex + 1,
+      totalCards,
+      url: source.url,
+      isLoggedIn: false,
     })
   }
 
@@ -211,7 +249,7 @@ export default function FeedCardStack({ cards }: FeedCardStackProps) {
               </p>
             </div>
             <div className="space-y-4">
-              <CardBody card={activeCard} />
+              <CardBody card={activeCard} onSourceClick={handleSourceClick} />
             </div>
           </div>
         </article>

--- a/src/components/features/feed/FeedShareButton.tsx
+++ b/src/components/features/feed/FeedShareButton.tsx
@@ -2,15 +2,25 @@
 
 import { useState } from 'react'
 
+import { trackFeedEvent } from '@/lib/analytics'
+
 type FeedShareButtonProps = {
   permalink: string
   title: string
   summary: string
+  entityType?: string
+  entityId?: string
 }
 
 type ShareStatus = 'idle' | 'shared' | 'copied' | 'error'
 
-export default function FeedShareButton({ permalink, title, summary }: FeedShareButtonProps) {
+export default function FeedShareButton({
+  permalink,
+  title,
+  summary,
+  entityType,
+  entityId,
+}: FeedShareButtonProps) {
   const [status, setStatus] = useState<ShareStatus>('idle')
 
   async function copyLink() {
@@ -25,6 +35,14 @@ export default function FeedShareButton({ permalink, title, summary }: FeedShare
   }
 
   async function handleShare() {
+    trackFeedEvent({
+      event: 'share_clicked',
+      entityType,
+      entityId,
+      url: permalink,
+      isLoggedIn: false,
+    })
+
     try {
       if (navigator.share) {
         await navigator.share({

--- a/src/components/features/feed/FeedSourceLink.tsx
+++ b/src/components/features/feed/FeedSourceLink.tsx
@@ -2,6 +2,7 @@ import type { CardSource } from '@/types/cards'
 
 type FeedSourceLinkProps = {
   source: CardSource
+  onClick?: () => void
 }
 
 function isSafeExternalUrl(url: string) {
@@ -13,7 +14,7 @@ function isSafeExternalUrl(url: string) {
   }
 }
 
-export default function FeedSourceLink({ source }: FeedSourceLinkProps) {
+export default function FeedSourceLink({ source, onClick }: FeedSourceLinkProps) {
   if (!isSafeExternalUrl(source.url)) {
     return (
       <span className="border-border bg-background/25 inline-flex min-h-11 items-center rounded-full border px-3 py-2 text-left">
@@ -28,6 +29,7 @@ export default function FeedSourceLink({ source }: FeedSourceLinkProps) {
       href={source.url}
       target="_blank"
       rel="noopener noreferrer"
+      onClick={onClick}
       className="border-border bg-background/25 hover:bg-background/40 inline-flex min-h-11 items-center rounded-full border px-3 py-2 text-left transition-colors"
     >
       <span className="text-foreground text-xs font-medium">{source.domain}</span>

--- a/src/components/features/feed/FeedView.tsx
+++ b/src/components/features/feed/FeedView.tsx
@@ -3,8 +3,10 @@
 // TODO(#18): 스와이프 UI 구현 시 스와이프 탐색 추가
 
 import Link from 'next/link'
+import { useEffect } from 'react'
 
 import FeedSourceLink from '@/components/features/feed/FeedSourceLink'
+import { trackFeedEvent } from '@/lib/analytics'
 import type { PublicIssueSummary } from '@/lib/public/feeds'
 import type { CardSource } from '@/types/cards'
 
@@ -65,6 +67,26 @@ function getContextSummary(issue: PublicIssueSummary | null): {
 
 export default function FeedView({ date, issues, initialIssueId, previousDate }: FeedViewProps) {
   const origin = typeof window === 'undefined' ? 'https://findori.app' : window.location.origin
+  const openedIssue =
+    issues.find((issue) => issue.id === initialIssueId) ??
+    issues.find((issue) => issue.entityType === 'stock') ??
+    issues[0]
+
+  useEffect(() => {
+    if (!openedIssue) {
+      return
+    }
+
+    trackFeedEvent({
+      event: 'feed_opened',
+      entityType: openedIssue.entityType,
+      entityId: openedIssue.entityId,
+      cardIndex: 1,
+      totalCards: openedIssue.cardsData?.length ?? 0,
+      isLoggedIn: false,
+    })
+  }, [openedIssue])
+
   const contextIssues = CONTEXT_SLOTS.map((slot) => {
     const issue =
       issues.find((candidate) => candidate.entityId === slot.entityId) ??
@@ -223,10 +245,16 @@ export default function FeedView({ date, issues, initialIssueId, previousDate }:
                   permalink={`${origin}/feed/${date}/issue/${issue.id}`}
                   title={issue.title}
                   summary={`${issue.entityName} 이슈 카드 스트림`}
+                  entityType={issue.entityType}
+                  entityId={issue.entityId}
                 />
               </div>
             </div>
-            <FeedCardStack cards={issue.cardsData} />
+            <FeedCardStack
+              cards={issue.cardsData}
+              entityType={issue.entityType}
+              entityId={issue.entityId}
+            />
           </section>
         ))}
       </main>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,41 @@
+export type FeedEventName = 'feed_opened' | 'card_swiped' | 'share_clicked' | 'source_clicked'
+
+export type FeedEventPayload = {
+  event: FeedEventName
+  entityType?: string
+  entityId?: string
+  cardIndex?: number
+  totalCards?: number
+  platform?: 'web'
+  isLoggedIn?: boolean
+  url?: string
+  path?: string
+}
+
+export function trackFeedEvent(payload: FeedEventPayload) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const endpoint = new URL('/api/events', window.location.origin).toString()
+  const body = JSON.stringify({
+    ...payload,
+    platform: 'web',
+    path: window.location.pathname,
+  })
+
+  if (navigator.sendBeacon) {
+    const blob = new Blob([body], { type: 'application/json' })
+    navigator.sendBeacon(endpoint, blob)
+    return
+  }
+
+  void fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body,
+    keepalive: true,
+  })
+}

--- a/tests/unit/api/events-route.test.ts
+++ b/tests/unit/api/events-route.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { POST } from '@/app/api/events/route'
+
+describe('POST /api/events', () => {
+  it('유효한 이벤트를 수신하면 ok를 반환한다', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    const response = await POST(
+      new Request('http://localhost/api/events', {
+        method: 'POST',
+        body: JSON.stringify({ event: 'feed_opened', entityType: 'stock', entityId: '005930' }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[feed-event]',
+      expect.objectContaining({ event: 'feed_opened', entityId: '005930' }),
+    )
+  })
+
+  it('이벤트가 유효하지 않으면 400을 반환한다', async () => {
+    const response = await POST(
+      new Request('http://localhost/api/events', {
+        method: 'POST',
+        body: JSON.stringify({ event: 'unknown' }),
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'invalid_event' })
+  })
+})

--- a/tests/unit/components/FeedCardStack.test.tsx
+++ b/tests/unit/components/FeedCardStack.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import FeedCardStack from '@/components/features/feed/FeedCardStack'
 import type { Card } from '@/types/cards'
@@ -47,6 +47,13 @@ const cards: Card[] = [
 ]
 
 describe('FeedCardStack', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: vi.fn().mockReturnValue(true),
+    })
+  })
+
   it('다음/이전 버튼으로 현재 카드를 이동하고 진행 상태를 갱신한다', () => {
     render(<FeedCardStack cards={cards} />)
 

--- a/tests/unit/components/FeedShareButton.test.tsx
+++ b/tests/unit/components/FeedShareButton.test.tsx
@@ -5,11 +5,13 @@ import FeedShareButton from '@/components/features/feed/FeedShareButton'
 
 const shareMock = vi.fn()
 const writeTextMock = vi.fn()
+const sendBeaconMock = vi.fn()
 
 describe('FeedShareButton', () => {
   beforeEach(() => {
     shareMock.mockReset()
     writeTextMock.mockReset()
+    sendBeaconMock.mockReset()
 
     Object.defineProperty(window, 'location', {
       configurable: true,
@@ -24,6 +26,11 @@ describe('FeedShareButton', () => {
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
       value: { writeText: writeTextMock },
+    })
+
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: sendBeaconMock,
     })
   })
 

--- a/tests/unit/components/FeedView.test.tsx
+++ b/tests/unit/components/FeedView.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import FeedDisclaimer from '@/components/features/feed/FeedDisclaimer'
 import FeedView from '@/components/features/feed/FeedView'
@@ -137,6 +137,13 @@ const contextIssue: PublicIssueSummary = {
 }
 
 describe('FeedView', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: vi.fn().mockReturnValue(true),
+    })
+  })
+
   it('카드 타입별 UI와 출처 링크를 렌더링한다', () => {
     render(<FeedView date="2026-03-20" issues={[sampleIssue]} previousDate="2026-03-19" />)
 

--- a/tests/unit/lib/analytics.test.ts
+++ b/tests/unit/lib/analytics.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+import { trackFeedEvent } from '@/lib/analytics'
+
+describe('trackFeedEvent', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('sendBeacon이 있으면 beacon으로 이벤트를 전송한다', () => {
+    const sendBeaconMock = vi.fn().mockReturnValue(true)
+    Object.defineProperty(navigator, 'sendBeacon', {
+      configurable: true,
+      value: sendBeaconMock,
+    })
+
+    trackFeedEvent({ event: 'feed_opened', entityType: 'stock', entityId: '005930' })
+
+    expect(sendBeaconMock).toHaveBeenCalledWith(
+      'http://localhost:3000/api/events',
+      expect.any(Blob),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- 공개 피드 핵심 이벤트(`feed_opened`, `card_swiped`, `share_clicked`, `source_clicked`)를 수집하는 공용 `trackFeedEvent()` 유틸을 추가했습니다.
- `/api/events` 엔드포인트를 만들어 이벤트를 서버 로그로 수신하도록 했고, feed UI 각 지점에 이벤트 호출을 연결했습니다.
- 이벤트 API/유틸/피드 컴포넌트 테스트를 보강해 회귀 없이 계측이 동작하는지 검증했습니다.

## Test plan
- `npm run test -- tests/unit/api/events-route.test.ts tests/unit/lib/analytics.test.ts tests/unit/components/FeedShareButton.test.tsx tests/unit/components/FeedCardStack.test.tsx tests/unit/components/FeedView.test.tsx` ✅
- `npm run validate` ✅
- `npm run build` ✅

Closes #29
