### PR TITLE
[Issue #25] OG 이미지 구현 (/api/og/issue/[id], 기본 OG 정적 이미지)

### DIFF
--- a/src/app/api/og/issue/[id]/route.ts
+++ b/src/app/api/og/issue/[id]/route.ts
@@ -1,12 +1,229 @@
-// TODO(#25): Satori로 동적 OG 이미지 생성 구현
+import { createElement } from 'react'
 
+import { ImageResponse } from 'next/og'
 import { NextResponse } from 'next/server'
+
+import { getPublicIssueById } from '@/lib/public/feeds'
+import type { Card, CardVisual } from '@/types/cards'
 
 type Params = Promise<{ id: string }>
 
-export async function GET(_request: Request, { params }: { params: Params }) {
-  await params // id는 향후 OG 이미지 생성 시 사용
+function getVisual(cards: Card[] | null): CardVisual {
+  const fallback = {
+    bg_from: '#0f172a',
+    bg_via: '#172554',
+    bg_to: '#020617',
+    accent: '#38bdf8',
+  }
 
-  // Stub: 기본 OG 이미지로 리다이렉트
-  return NextResponse.redirect(new URL('/og-default.png', _request.url))
+  if (!cards || cards.length === 0) {
+    return fallback
+  }
+
+  return cards[0]?.visual ?? fallback
+}
+
+function getSummary(cards: Card[] | null) {
+  if (!cards || cards.length === 0) {
+    return '오늘의 이슈 카드 스트림'
+  }
+
+  const explanationCard = cards.find(
+    (card) => card.type === 'reason' || card.type === 'bullish' || card.type === 'bearish',
+  )
+
+  if (explanationCard && 'body' in explanationCard) {
+    return explanationCard.body
+  }
+
+  const coverCard = cards.find((card) => card.type === 'cover')
+  if (coverCard && 'sub' in coverCard) {
+    return coverCard.sub
+  }
+
+  return '오늘의 이슈 카드 스트림'
+}
+
+export async function GET(request: Request, { params }: { params: Params }) {
+  const { id } = await params
+
+  try {
+    const issue = await getPublicIssueById(id)
+
+    if (!issue) {
+      return NextResponse.redirect(new URL('/og-default.png', request.url))
+    }
+
+    const visual = getVisual(issue.cardsData)
+    const summary = getSummary(issue.cardsData)
+
+    const tree = createElement(
+      'div',
+      {
+        style: {
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: '56px',
+          color: 'white',
+          backgroundImage: `linear-gradient(160deg, ${visual.bg_from} 0%, ${visual.bg_via} 55%, ${visual.bg_to} 100%)`,
+          fontFamily: 'Pretendard, Inter, Apple SD Gothic Neo, Noto Sans KR, sans-serif',
+        },
+      },
+      createElement(
+        'div',
+        {
+          style: {
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+          },
+        },
+        createElement(
+          'div',
+          {
+            style: {
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '12px',
+              maxWidth: '760px',
+            },
+          },
+          createElement(
+            'div',
+            {
+              style: {
+                display: 'flex',
+                alignItems: 'center',
+                gap: '12px',
+                fontSize: '24px',
+                opacity: 0.86,
+              },
+            },
+            createElement('span', null, issue.entityName),
+            createElement(
+              'span',
+              {
+                style: {
+                  display: 'flex',
+                  padding: '8px 16px',
+                  borderRadius: '999px',
+                  background: `${visual.accent}33`,
+                  color: visual.accent,
+                  fontWeight: 700,
+                },
+              },
+              issue.changeValue ?? '오늘의 이슈',
+            ),
+          ),
+          createElement(
+            'div',
+            {
+              style: {
+                display: 'flex',
+                fontSize: '64px',
+                lineHeight: 1.18,
+                fontWeight: 800,
+                letterSpacing: '-0.04em',
+                whiteSpace: 'pre-wrap',
+              },
+            },
+            issue.title,
+          ),
+        ),
+        createElement(
+          'div',
+          {
+            style: {
+              display: 'flex',
+              padding: '12px 20px',
+              borderRadius: '999px',
+              border: `1px solid ${visual.accent}66`,
+              fontSize: '20px',
+              color: '#e2e8f0',
+            },
+          },
+          'Findori',
+        ),
+      ),
+      createElement(
+        'div',
+        {
+          style: {
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '16px',
+          },
+        },
+        createElement(
+          'div',
+          {
+            style: {
+              display: 'flex',
+              width: '100%',
+              height: '6px',
+              borderRadius: '999px',
+              background: 'rgba(255,255,255,0.12)',
+            },
+          },
+          createElement('div', {
+            style: {
+              display: 'flex',
+              width: '42%',
+              borderRadius: '999px',
+              background: visual.accent,
+            },
+          }),
+        ),
+        createElement(
+          'div',
+          {
+            style: {
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'flex-end',
+              gap: '24px',
+            },
+          },
+          createElement(
+            'div',
+            {
+              style: {
+                display: 'flex',
+                maxWidth: '820px',
+                fontSize: '28px',
+                lineHeight: 1.45,
+                color: '#e2e8f0',
+              },
+            },
+            summary,
+          ),
+          createElement(
+            'div',
+            {
+              style: {
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'flex-end',
+                gap: '10px',
+                fontSize: '20px',
+                color: '#cbd5e1',
+              },
+            },
+            createElement('span', null, issue.feedDate),
+            createElement('span', null, '오늘의 경제 이슈'),
+          ),
+        ),
+      ),
+    )
+
+    return new ImageResponse(tree, {
+      width: 1200,
+      height: 630,
+    })
+  } catch {
+    return NextResponse.redirect(new URL('/og-default.png', request.url))
+  }
 }

--- a/tests/unit/api/og-issue-route.test.ts
+++ b/tests/unit/api/og-issue-route.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetPublicIssueById, imageResponseMock } = vi.hoisted(() => ({
+  mockGetPublicIssueById: vi.fn(),
+  imageResponseMock: vi.fn(function MockImageResponse(this: Record<string, unknown>, ...args) {
+    this.args = args
+  }),
+}))
+
+vi.mock('@/lib/public/feeds', () => ({
+  getPublicIssueById: mockGetPublicIssueById,
+}))
+
+vi.mock('next/og', () => ({
+  ImageResponse: imageResponseMock,
+}))
+
+import { GET } from '@/app/api/og/issue/[id]/route'
+
+describe('GET /api/og/issue/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('공개 이슈가 있으면 ImageResponse를 반환한다', async () => {
+    mockGetPublicIssueById.mockResolvedValue({
+      id: 'issue-1',
+      feedDate: '2026-03-20',
+      entityType: 'stock',
+      entityId: '005930',
+      entityName: '삼성전자',
+      title: '삼성전자 급등',
+      changeValue: '+3.2%',
+      channel: 'v1',
+      tags: ['반도체'],
+      cardsData: [
+        {
+          id: 1,
+          type: 'cover',
+          tag: '속보',
+          title: '삼성전자 급등',
+          sub: '외국인 순매수 확대',
+          visual: {
+            bg_from: '#0f172a',
+            bg_via: '#1e3a5f',
+            bg_to: '#0f172a',
+            accent: '#3B82F6',
+          },
+        },
+      ],
+    })
+
+    const response = await GET(new Request('http://localhost/api/og/issue/issue-1'), {
+      params: Promise.resolve({ id: 'issue-1' }),
+    })
+
+    expect(mockGetPublicIssueById).toHaveBeenCalledWith('issue-1')
+    expect(imageResponseMock).toHaveBeenCalled()
+    expect(response).toBeInstanceOf(imageResponseMock as unknown as typeof Object)
+  })
+
+  it('이슈가 없으면 기본 OG 이미지로 리다이렉트한다', async () => {
+    mockGetPublicIssueById.mockResolvedValue(null)
+
+    const response = await GET(new Request('http://localhost/api/og/issue/missing'), {
+      params: Promise.resolve({ id: 'missing' }),
+    })
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('http://localhost/og-default.png')
+  })
+})


### PR DESCRIPTION
## Summary

- 기본 OG 이미지 리다이렉트 stub을 동적 이미지 생성으로 교체했습니다.
- 이슈 제목, 엔티티명, 변동 수치, cover 카드 비주얼을 활용해 1200×630 공유 이미지를 생성합니다.
- 공개 이슈/fallback 경로를 검증하는 OG route 단위 테스트 2개를 추가했습니다.

## Test plan

- [ ] \`/api/og/issue/[id]\`에 유효한 이슈 ID를 넣어 이미지가 정상 렌더링되는지 확인
- [ ] 존재하지 않는 ID 요청 시 fallback 이미지(또는 404)로 처리되는지 확인
- [ ] SNS 공유 시 OG 이미지가 미리보기로 노출되는지 확인 (링크 디버거 활용)

Closes #25