### PR TITLE
[Issue #21] 카테고리 태그 노출 및 태그 fallback 처리 구현

### DIFF
--- a/src/components/features/feed/FeedView.tsx
+++ b/src/components/features/feed/FeedView.tsx
@@ -214,7 +214,7 @@ export default function FeedView({ date, issues, initialIssueId, previousDate }:
                   <span className="bg-background/70 text-muted rounded-full px-3 py-1 text-[11px] font-semibold tracking-[0.16em] uppercase">
                     {issue.entityType}
                   </span>
-                  {issue.tags.map((tag) => (
+                  {(issue.tags.length > 0 ? issue.tags : ['기타']).map((tag) => (
                     <span
                       key={tag}
                       className="bg-surface-raised text-muted rounded-full px-3 py-1 text-xs"


### PR DESCRIPTION
## Summary

- `FeedView`에서 이슈 태그 배열이 비어있을 때 "기타" 기본 태그를 표시하도록 fallback 처리 추가
- feature-spec.md FR-08/FR-09 요구사항: "태그 누락 데이터 수신: 기본 태그(예: 기타)로 fallback"

## Test plan

- [ ] 태그가 있는 이슈에서 태그가 정상 표시된다
- [ ] 태그 데이터가 없는 이슈에서 "기타" 태그가 표시된다
- [ ] `npm run validate` 통과

Closes #21