### PR TITLE
[Issue #28] 반응형 정합성 구현 (모바일 360-430, 데스크톱 최대 960)

### DIFF
--- a/src/components/features/feed/FeedCardStack.tsx
+++ b/src/components/features/feed/FeedCardStack.tsx
@@ -236,7 +236,7 @@ export default function FeedCardStack({ cards, entityType, entityId }: FeedCardS
       >
         <article
           key={activeCard.id}
-          className="overflow-hidden rounded-[28px] border px-5 py-5 text-white sm:px-6 sm:py-6"
+          className="overflow-hidden rounded-[28px] border px-4 py-5 text-white sm:px-6 sm:py-6"
           style={cardStyle(activeCard)}
         >
           <div className="space-y-5">

--- a/src/components/features/feed/FeedView.tsx
+++ b/src/components/features/feed/FeedView.tsx
@@ -107,7 +107,7 @@ export default function FeedView({ date, issues, initialIssueId, previousDate }:
     <div className="flex min-h-screen flex-col pb-10">
       <header className="border-border border-b px-4 py-4">
         <p className="text-muted text-sm">{date}</p>
-        <div className="mt-2 flex items-end justify-between gap-4">
+        <div className="mt-2 flex flex-wrap items-end justify-between gap-4">
           <div>
             <h1 className="text-foreground text-xl font-semibold">오늘의 이슈 카드 스트림</h1>
             <p className="text-muted mt-1 text-sm">이슈 {issues.length}건</p>
@@ -144,11 +144,11 @@ export default function FeedView({ date, issues, initialIssueId, previousDate }:
               </p>
               <h2 className="mt-2 text-xl font-semibold text-white">대표 지수·환율 맥락 카드</h2>
             </div>
-            <p className="max-w-xl text-sm leading-6 text-slate-300">
+            <p className="max-w-full text-sm leading-6 text-slate-300 sm:max-w-xl">
               코스피, 나스닥, USD/KRW 흐름을 먼저 확인하고 개별 이슈 카드로 내려가세요.
             </p>
           </div>
-          <div className="mt-5 grid gap-4 lg:grid-cols-3">
+          <div className="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {contextIssues.map((item) => (
               <article
                 key={item.entityId}


### PR DESCRIPTION
## Summary

Design Guidelines 모바일 360-430px / 데스크톱 960px 기준 반응형 정합성 개선.

- **Market Context 그리드**: `lg:grid-cols-3` → `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3` — 360px에서 단일 컬럼으로 올바르게 렌더링
- **설명 텍스트**: `max-w-xl` → `max-w-full sm:max-w-xl` — 360px 뷰포트에서 텍스트 오버플로 방지
- **헤더**: `flex-wrap` 추가 — 좁은 뷰포트에서 날짜 탐색 버튼이 줄바꿈되어 레이아웃 깨짐 방지
- **카드 패딩**: `px-5` → `px-4` — 부모 `p-4`와 일치시켜 16px 최소 마진 준수

## Test plan

- [ ] 360px 뷰포트에서 Market Context 카드가 1열 세로 배열로 표시된다
- [ ] 360px 뷰포트에서 콘텐츠가 화면 밖으로 넘치지 않는다
- [ ] 768px(sm) 이상에서 2열, 1024px(lg) 이상에서 3열로 표시된다
- [ ] 960px 데스크톱에서 레이아웃이 max-width 내에서 정상 표시된다
- [ ] `npm run validate` 통과

Closes #28