### PR TITLE
[Issue #27] 접근성 기준 적용 (대비/44x44/alt/포커스 링)

### DIFF
--- a/src/app/(public)/error.tsx
+++ b/src/app/(public)/error.tsx
@@ -25,26 +25,28 @@ export default function PublicError({ error, reset }: ErrorProps) {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-6 px-4 text-center">
       <div className="flex flex-col items-center gap-2">
-        <p className="text-2xl">⚠️</p>
+        <p className="text-2xl" role="img" aria-label="오류">
+          ⚠️
+        </p>
         <h1 className="text-foreground text-lg font-semibold">피드를 불러오지 못했습니다</h1>
         <p className="text-muted text-sm">잠시 후 다시 시도해 주세요.</p>
       </div>
       <div className="flex flex-wrap justify-center gap-3">
         <button
           onClick={reset}
-          className="bg-accent-blue text-foreground rounded-lg px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-80"
+          className="bg-accent-blue text-foreground rounded-lg px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           다시 시도
         </button>
         <Link
           href="/"
-          className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors"
+          className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           홈으로 이동
         </Link>
         <button
           onClick={handleCopyLink}
-          className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors"
+          className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           {copied ? '복사됨!' : '링크 복사'}
         </button>

--- a/src/components/features/feed/FeedCardStack.tsx
+++ b/src/components/features/feed/FeedCardStack.tsx
@@ -259,7 +259,7 @@ export default function FeedCardStack({ cards, entityType, entityId }: FeedCardS
           type="button"
           onClick={() => moveCard('prev')}
           disabled={activeIndex === 0}
-          className="min-h-11 rounded-full border border-white/12 px-4 py-2 text-sm font-medium text-white/80 transition disabled:cursor-not-allowed disabled:opacity-40"
+          className="min-h-11 rounded-full border border-white/12 px-4 py-2 text-sm font-medium text-white/80 transition focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
         >
           이전 카드
         </button>
@@ -270,7 +270,7 @@ export default function FeedCardStack({ cards, entityType, entityId }: FeedCardS
           type="button"
           onClick={() => moveCard('next')}
           disabled={activeIndex === totalCards - 1}
-          className="min-h-11 rounded-full border border-white/12 px-4 py-2 text-sm font-medium text-white/80 transition disabled:cursor-not-allowed disabled:opacity-40"
+          className="min-h-11 rounded-full border border-white/12 px-4 py-2 text-sm font-medium text-white/80 transition focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
         >
           다음 카드
         </button>

--- a/src/components/features/feed/FeedEmptyState.tsx
+++ b/src/components/features/feed/FeedEmptyState.tsx
@@ -11,7 +11,9 @@ export default function FeedEmptyState({ date, previousDate }: FeedEmptyStatePro
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-6 px-4 text-center">
       <div className="flex flex-col items-center gap-2">
-        <p className="text-2xl">📭</p>
+        <p className="text-2xl" role="img" aria-label="빈 피드">
+          📭
+        </p>
         <h1 className="text-foreground text-lg font-semibold">
           {date ? `${date} 피드가 없습니다` : '발행된 피드가 없습니다'}
         </h1>
@@ -24,27 +26,27 @@ export default function FeedEmptyState({ date, previousDate }: FeedEmptyStatePro
       <div className="flex flex-wrap justify-center gap-3">
         <button
           onClick={() => window.location.reload()}
-          className="bg-accent-blue text-foreground rounded-lg px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-80"
+          className="bg-accent-blue text-foreground rounded-lg px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           재시도
         </button>
         {previousDate ? (
           <Link
             href={`/feed/${previousDate}`}
-            className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors"
+            className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
           >
             이전 발행일 보기
           </Link>
         ) : null}
         <Link
           href="/feed/latest"
-          className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors"
+          className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           최신 피드 보기
         </Link>
         <Link
           href="/"
-          className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors"
+          className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           홈으로 이동
         </Link>

--- a/src/components/features/feed/FeedErrorState.tsx
+++ b/src/components/features/feed/FeedErrorState.tsx
@@ -16,26 +16,28 @@ export default function FeedErrorState() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-6 px-4 text-center">
       <div className="flex flex-col items-center gap-2">
-        <p className="text-2xl">⚠️</p>
+        <p className="text-2xl" role="img" aria-label="오류">
+          ⚠️
+        </p>
         <h1 className="text-foreground text-lg font-semibold">피드를 불러오지 못했습니다</h1>
         <p className="text-muted text-sm">잠시 후 다시 시도해 주세요.</p>
       </div>
       <div className="flex flex-wrap justify-center gap-3">
         <button
           onClick={() => window.location.reload()}
-          className="bg-accent-blue text-foreground rounded-lg px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-80"
+          className="bg-accent-blue text-foreground rounded-lg px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           다시 시도
         </button>
         <Link
           href="/"
-          className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors"
+          className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           홈으로 이동
         </Link>
         <button
           onClick={handleCopyLink}
-          className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors"
+          className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           {copied ? '복사됨!' : '링크 복사'}
         </button>

--- a/src/components/features/feed/FeedShareButton.tsx
+++ b/src/components/features/feed/FeedShareButton.tsx
@@ -78,7 +78,7 @@ export default function FeedShareButton({
       <button
         type="button"
         onClick={handleShare}
-        className="min-h-11 rounded-full border border-white/12 px-4 py-2 text-sm font-medium text-white/80 transition hover:border-white/30 hover:text-white"
+        className="min-h-11 rounded-full border border-white/12 px-4 py-2 text-sm font-medium text-white/80 transition hover:border-white/30 hover:text-white focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-1 focus-visible:outline-none"
       >
         공유
       </button>

--- a/src/components/features/feed/FeedView.tsx
+++ b/src/components/features/feed/FeedView.tsx
@@ -169,7 +169,10 @@ export default function FeedView({ date, issues, initialIssueId, previousDate }:
                         : 'bg-emerald-400/10 text-emerald-200',
                     ].join(' ')}
                   >
-                    {item.issue?.changeValue ?? '업데이트 지연'}
+                    {item.issue?.changeValue
+                      ? (item.issue.changeValue.startsWith('-') ? '▼ ' : '▲ ') +
+                        item.issue.changeValue
+                      : '업데이트 지연'}
                   </span>
                 </div>
                 <p className="mt-4 line-clamp-3 text-sm leading-6 text-slate-200">{item.summary}</p>
@@ -238,7 +241,7 @@ export default function FeedView({ date, issues, initialIssueId, previousDate }:
                       issue.changeValue.startsWith('-') ? 'text-accent-red' : 'text-accent-green',
                     ].join(' ')}
                   >
-                    {issue.changeValue}
+                    {(issue.changeValue.startsWith('-') ? '▼ ' : '▲ ') + issue.changeValue}
                   </span>
                 )}
                 <FeedShareButton


### PR DESCRIPTION
## Summary

- 색상만으로 상태를 표현하던 `changeValue` 배지에 ▲/▼ 방향 기호 추가 (색맹 접근성)
- 카드 네비게이션 버튼, 공유 버튼, 에러/빈 상태 버튼/링크에 `focus-visible:ring` 포커스 링 추가
- 이모지(`⚠️`, `📭`)에 `role="img"` + `aria-label` 추가

## Test plan

- [ ] 키보드(Tab)로 버튼/링크 탐색 시 포커스 링 표시 확인
- [ ] changeValue 배지에 ▲/▼ 기호가 색상과 함께 노출되는지 확인
- [ ] 스크린 리더에서 이모지가 의미 있는 레이블로 읽히는지 확인