### PR TITLE
fix: Claude tool strict: true 제거 (Grammar compilation timeout)

### DIFF
--- a/src/lib/pipeline/generate.ts
+++ b/src/lib/pipeline/generate.ts
@@ -42,7 +42,6 @@ function buildToolSchema() {
   return {
     name: GENERATE_TOOL_NAME,
     description: '기사 목록을 읽고 이슈 카드 초안 배열을 생성합니다.',
-    strict: true,
     input_schema: {
       type: 'object' as const,
       properties: {


### PR DESCRIPTION
## 원인
`buildToolSchema()`에 `strict: true`가 설정되어 있어 Claude API가 복잡한 중첩 스키마(cards → visual/sources/quotes/items)를 grammar로 컴파일할 때 타임아웃이 발생했습니다.

## 영향
3/17-3/23 cron 실행이 전부 120-180초 후 `Grammar compilation timed out` 400 에러로 실패. 기사는 수집되고 있었으나 AI 카드 생성 단계에서 매일 막힘.

## 수정
`strict: true` 한 줄 제거. Claude는 strict 없이도 tool schema에 맞춰 응답을 생성합니다.