### PR TITLE
fix: 파이프라인 catch 블록에서 수집된 기사 통계 보존

### DIFF
--- a/src/lib/pipeline/index.ts
+++ b/src/lib/pipeline/index.ts
@@ -77,8 +77,10 @@ export async function runPipeline(
   const startedAt = new Date()
   const log = await startPipelineRun(client, date, params.triggeredBy, startedAt)
 
+  let collected: Awaited<ReturnType<typeof collectArticles>> | undefined
+
   try {
-    const collected = await collectArticles(client, date)
+    collected = await collectArticles(client, date)
     const generated = await generateIssues(collected.articles)
     const errors = [...collected.errors, ...generated.errors]
 
@@ -127,9 +129,9 @@ export async function runPipeline(
     await finishPipelineRun(client, log.id, {
       status: 'failed',
       completedAt,
-      articlesCollected: 0,
-      articlesRaw: 0,
-      sourceStats: [],
+      articlesCollected: collected?.articles.length ?? 0,
+      articlesRaw: collected?.articlesRaw ?? 0,
+      sourceStats: collected?.sourceStats ?? [],
       issuesCreated: 0,
       errors: [pipelineError],
     })


### PR DESCRIPTION
## 문제
`generateIssues` 등 collect 이후 단계에서 오류가 발생하면 catch 블록에서 `articlesCollected`, `articlesRaw`, `sourceStats`가 0/빈값으로 하드코딩되어 저장됐습니다.

실제로는 기사가 수집됐음에도 로그에는 0건으로 표시되어 운영 중 원인 파악이 어려웠습니다. (3/17~3/23 Grammar timeout 실패 시 확인)

## 수정
`collected`를 try 블록 바깥으로 스코프를 올려 catch에서 실제 수집 결과를 참조하도록 변경. 수집 전에 오류가 나면 기존대로 0/빈값 fallback.

```ts
let collected: Awaited<ReturnType<typeof collectArticles>> | undefined

try {
  collected = await collectArticles(...)
  ...
} catch {
  articlesCollected: collected?.articles.length ?? 0,  // 실제값 보존
  articlesRaw: collected?.articlesRaw ?? 0,
  sourceStats: collected?.sourceStats ?? [],
}
```