### PR TITLE
fix: Claude 응답 max_tokens 4096 → 8192

### DIFF
--- a/src/lib/pipeline/generate.ts
+++ b/src/lib/pipeline/generate.ts
@@ -410,7 +410,7 @@ export async function generateIssues(
   const anthropic = deps.anthropic ?? getAnthropicClient()
   const response = await anthropic.messages.create({
     model: process.env.ANTHROPIC_MODEL ?? DEFAULT_MODEL,
-    max_tokens: 4096,
+    max_tokens: 8192,
     temperature: 0.2,
     system: buildSystemPrompt(),
     messages: [
@@ -473,7 +473,7 @@ export async function generateContextIssues(
   const anthropic = deps.anthropic ?? getAnthropicClient()
   const response = await anthropic.messages.create({
     model: process.env.ANTHROPIC_MODEL ?? DEFAULT_MODEL,
-    max_tokens: 4096,
+    max_tokens: 8192,
     temperature: 0.2,
     system: buildSystemPrompt(),
     messages: [


### PR DESCRIPTION
## 문제
기사 123건 처리 시 Claude 응답이 4096 토큰에서 잘려 `tool_use.input`이 불완전해지고, Zod 파싱에서 `issues: undefined` 오류 발생.

## 수정
`generateIssues`, `generateContextIssues` 두 함수 모두 `max_tokens: 8192`(모델 최대값)으로 상향.

## 한계
8192토큰도 기사 수가 매우 많거나 이슈가 많으면 부족할 수 있음. 근본 해결은 기사 배치 분할이나 이슈 수 제한이지만 그건 별도 작업.