### PR TITLE
docs: CLAUDE.md 프로젝트 구조·명령어·운영 규칙 보강

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,36 @@ Auto-generated from all feature plans. Last updated: 2026-03-24
 
 ```text
 src/
-tests/
+├── app/
+│   ├── (admin)/admin/          # Admin UI (피드·매체·파이프라인 관리)
+│   ├── api/admin/              # Admin API (pipeline/run, logs, feeds, issues, sources)
+│   ├── api/cron/pipeline/      # Vercel cron 엔드포인트 (매일 22:00 KST)
+│   └── api/feeds|issues|og/    # 공개 피드 API
+├── lib/
+│   ├── pipeline/               # 파이프라인 핵심 로직
+│   │   ├── collect.ts          # RSS 수집 (소스당 최대 30건, content 500자)
+│   │   ├── filter.ts           # Haiku 1차 필터 (투자 관련 상위 10건)
+│   │   ├── generate.ts         # Sonnet 카드 생성 (최대 3개 이슈, max_tokens 8192)
+│   │   ├── log.ts              # 실행 로그 (토큰/비용 포함)
+│   │   ├── store.ts            # draft feed/issue DB 저장
+│   │   └── index.ts            # 파이프라인 오케스트레이터
+│   ├── cards/                  # 카드 타입 파서/검증
+│   └── supabase/               # Supabase 클라이언트 (admin/server/client)
+├── components/features/admin/  # Admin UI 컴포넌트
+└── types/                      # TypeScript 타입 (pipeline, cards, database.types)
+
+supabase/migrations/            # DB 마이그레이션 (배포 전 적용 필요)
+specs/                          # 기능별 설계 문서 (히스토리)
 ```
 
 ## Commands
 
-npm test && npm run lint
+```bash
+npm run dev      # 로컬 개발 서버
+npm run build    # 프로덕션 빌드 (품질 게이트)
+npx tsc --noEmit # 타입 검사
+npm run lint     # 린트
+```
 
 ## Code Style
 
@@ -26,4 +50,10 @@ TypeScript 5 / Next.js 15 (App Router): Follow standard conventions
 - 054-pipeline-cost-opt: Added TypeScript 5 / Next.js 15 (App Router) + Anthropic SDK (`@anthropic-ai/sdk`), Supabase JS, Zod
 
 <!-- MANUAL ADDITIONS START -->
+## 운영 규칙
+
+- **브랜치 보호**: main 직접 push 불가. PR 필수.
+- **DB 마이그레이션**: `supabase/migrations/`에 파일 추가 시 배포 전 Supabase Dashboard SQL Editor에서 직접 실행 필요.
+- **파이프라인 구조**: collect → filter(Haiku) → generate(Sonnet) → store. 이슈 최대 3개, 비용 로깅 포함.
+- **Vercel cron**: `vercel.json` — 매일 UTC 13:00 (KST 22:00) 자동 실행.
 <!-- MANUAL ADDITIONS END -->


### PR DESCRIPTION
## 변경 이유
CLAUDE.md는 Claude Code가 매번 읽는 에이전트 컨텍스트인데 Project Structure가 `src/` + `tests/` 두 줄, Commands에 존재하지 않는 `npm test` 포함 등 실제 도움이 안 되는 수준이었습니다.

## 변경 범위
- Project Structure: 실제 디렉토리 구조 반영 (pipeline/, filter.ts 등 포함)
- Commands: `npm run dev`, `npm run build`, `npx tsc --noEmit` 정확히 기재
- MANUAL ADDITIONS: 브랜치 보호, DB 마이그레이션 운영 규칙, 파이프라인 구조 요약, Vercel cron 시간 추가

## 검증
문서 변경만, 빌드 영향 없음