### PR TITLE
docs: README AI Agent Workflow 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
 
 핀도리(Findori)는 개인 투자자를 위해 금융 이슈를 카드형으로 쉽게 풀어주는 앱/웹 서비스입니다.
 
-## Codex Workflow
+## AI Agent Workflow
 
-이 저장소는 Codex를 단순 질의응답 도구가 아니라 저장소 내장형 실행 에이전트로 사용하는 것을 기본으로 합니다.
+이 저장소는 AI 에이전트를 단순 질의응답 도구가 아니라 저장소 내장형 실행 에이전트로 사용하는 것을 기본으로 합니다. 현재 **Claude Code**와 **Codex** 양쪽을 지원합니다.
 
-- 저장소 규칙: `AGENTS.md` -> `docs/agent-guidelines.md`
-- Speckit 프롬프트: `.codex/prompts/`
-- repo-local skill: `.codex/skills/`
-- 구현 흐름: `spec -> plan -> tasks -> implement`
-- 기본 품질 게이트: `npm run validate`, `npm run test`, 필요 시 `npm run build`
+- 저장소 규칙: `docs/agent-guidelines.md`
+- 에이전트 컨텍스트: `CLAUDE.md` (Claude Code), `AGENTS.md` → `docs/agent-guidelines.md` (Codex)
+- Speckit 프롬프트: `.specify/templates/`, `.codex/prompts/`
+- repo-local skill: `.specify/`, `.codex/skills/`
+- 구현 흐름: `spec → plan → tasks → implement`
+- 품질 게이트: `npx tsc --noEmit`, `npm run build`
 
-repo-local skill을 로컬 Codex 환경에 설치하려면 아래 스크립트를 사용합니다.
+Codex repo-local skill을 로컬 환경에 설치하려면:
 
 ```bash
 bash scripts/install-codex-speckit-skills.sh


### PR DESCRIPTION
## 변경 이유
README의 Workflow 섹션이 Codex만 언급하고 있었으나 현재 Claude Code를 주력으로 사용 중.

## 변경 범위
- 섹션명: `Codex Workflow` → `AI Agent Workflow`
- Claude Code(`CLAUDE.md`)와 Codex 양쪽 에이전트 컨텍스트 명시
- Speckit 경로(`.specify/`) 추가
- 품질 게이트 명령어를 실제 사용 중인 것으로 정정 (`npm run validate` → `npx tsc --noEmit`, `npm run build`)