### PR TITLE
[Issue #10] Admin 화이트리스트 매체 관리 기능 구현

### DIFF
--- a/src/app/(admin)/admin/sources/page.tsx
+++ b/src/app/(admin)/admin/sources/page.tsx
@@ -1,10 +1,30 @@
-// TODO(#10): Admin 화이트리스트 매체 관리 구현
+import { SourcesManager } from '@/components/features/admin/SourcesManager'
+import { getAdminSources } from '@/lib/admin/sources'
 
-export default function AdminSourcesPage() {
-  return (
-    <div className="p-6">
-      <h1 className="text-xl font-bold">매체 관리</h1>
-      <p className="text-muted mt-2">화이트리스트 매체 추가/비활성화 (구현 예정)</p>
-    </div>
-  )
+export default async function AdminSourcesPage() {
+  try {
+    const sources = await getAdminSources()
+
+    return (
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <p className="text-sm tracking-[0.2em] text-slate-400 uppercase">Sources</p>
+          <h1 className="text-3xl font-bold text-slate-50">화이트리스트 매체 관리</h1>
+          <p className="text-sm text-slate-300">
+            파이프라인이 RSS를 수집할 매체를 등록하고 활성/비활성을 관리합니다.
+          </p>
+        </div>
+        <SourcesManager initialSources={sources} />
+      </section>
+    )
+  } catch {
+    return (
+      <section className="space-y-3">
+        <h1 className="text-3xl font-bold text-slate-50">화이트리스트 매체 관리</h1>
+        <div className="rounded-2xl bg-rose-950/40 px-5 py-4 text-sm text-rose-100">
+          매체 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+        </div>
+      </section>
+    )
+  }
 }

--- a/src/app/api/admin/sources/[id]/route.ts
+++ b/src/app/api/admin/sources/[id]/route.ts
@@ -1,10 +1,45 @@
-// TODO(#10): 매체 활성/비활성 구현
-
 import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { requireAdminSession } from '@/lib/admin/session'
+import { toggleSourceActive, SourceNotFoundError } from '@/lib/admin/sources'
+
+const PatchSourceSchema = z.object({
+  active: z.boolean(),
+})
 
 type Params = Promise<{ id: string }>
 
-export async function PATCH(_request: Request, { params }: { params: Params }) {
+export async function PATCH(request: Request, { params }: { params: Params }) {
+  const session = await requireAdminSession(request)
+  if (!session.valid) {
+    return session.response
+  }
+
   const { id } = await params
-  return NextResponse.json({ error: 'not_implemented', id }, { status: 501 })
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+
+  const parsed = PatchSourceSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'validation_error', details: parsed.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const source = await toggleSourceActive(id, parsed.data.active)
+    return NextResponse.json({ source }, { status: 200 })
+  } catch (err) {
+    if (err instanceof SourceNotFoundError) {
+      return NextResponse.json({ error: 'not_found' }, { status: 404 })
+    }
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 })
+  }
 }

--- a/src/app/api/admin/sources/route.ts
+++ b/src/app/api/admin/sources/route.ts
@@ -1,11 +1,56 @@
-// TODO(#10): 화이트리스트 매체 관리 구현
-
 import { NextResponse } from 'next/server'
+import { z } from 'zod'
 
-export async function GET() {
-  return NextResponse.json({ sources: [] }, { status: 200 })
+import { requireAdminSession } from '@/lib/admin/session'
+import { createSource, getAdminSources, SourceDuplicateError } from '@/lib/admin/sources'
+
+const CreateSourceSchema = z.object({
+  name: z.string().min(1).max(100),
+  rssUrl: z.string().url(),
+})
+
+export async function GET(request: Request) {
+  const session = await requireAdminSession(request)
+  if (!session.valid) {
+    return session.response
+  }
+
+  try {
+    const sources = await getAdminSources()
+    return NextResponse.json({ sources }, { status: 200 })
+  } catch {
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 })
+  }
 }
 
-export async function POST() {
-  return NextResponse.json({ error: 'not_implemented' }, { status: 501 })
+export async function POST(request: Request) {
+  const session = await requireAdminSession(request)
+  if (!session.valid) {
+    return session.response
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
+  }
+
+  const parsed = CreateSourceSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'validation_error', details: parsed.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const source = await createSource(parsed.data)
+    return NextResponse.json({ source }, { status: 201 })
+  } catch (err) {
+    if (err instanceof SourceDuplicateError) {
+      return NextResponse.json({ error: 'duplicate_rss_url' }, { status: 409 })
+    }
+    return NextResponse.json({ error: 'internal_error' }, { status: 500 })
+  }
 }

--- a/src/components/features/admin/SourcesManager.tsx
+++ b/src/components/features/admin/SourcesManager.tsx
@@ -1,0 +1,194 @@
+'use client'
+
+import { useState } from 'react'
+
+import type { AdminMediaSource } from '@/lib/admin/sources'
+
+type Props = {
+  initialSources: AdminMediaSource[]
+}
+
+export function SourcesManager({ initialSources }: Props) {
+  const [sources, setSources] = useState(initialSources)
+  const [name, setName] = useState('')
+  const [rssUrl, setRssUrl] = useState('')
+  const [adding, setAdding] = useState(false)
+  const [togglingId, setTogglingId] = useState<string | null>(null)
+  const [message, setMessage] = useState<{ kind: 'ok' | 'error'; text: string } | null>(null)
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault()
+    setAdding(true)
+    setMessage(null)
+
+    try {
+      const res = await fetch('/api/admin/sources', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: name.trim(), rssUrl: rssUrl.trim() }),
+      })
+      const body = await res.json()
+
+      if (res.status === 409) {
+        setMessage({ kind: 'error', text: '이미 등록된 RSS URL입니다.' })
+        return
+      }
+
+      if (!res.ok) {
+        setMessage({ kind: 'error', text: body.error ?? '등록 실패' })
+        return
+      }
+
+      setSources((prev) => [...prev, body.source as AdminMediaSource])
+      setName('')
+      setRssUrl('')
+      setMessage({ kind: 'ok', text: `"${(body.source as AdminMediaSource).name}" 매체가 등록되었습니다.` })
+    } catch {
+      setMessage({ kind: 'error', text: '네트워크 오류가 발생했습니다.' })
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  async function handleToggle(source: AdminMediaSource) {
+    setTogglingId(source.id)
+    setMessage(null)
+
+    try {
+      const res = await fetch(`/api/admin/sources/${source.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ active: !source.active }),
+      })
+      const body = await res.json()
+
+      if (!res.ok) {
+        setMessage({ kind: 'error', text: body.error ?? '업데이트 실패' })
+        return
+      }
+
+      const updated = body.source as AdminMediaSource
+      setSources((prev) => prev.map((s) => (s.id === updated.id ? updated : s)))
+    } catch {
+      setMessage({ kind: 'error', text: '네트워크 오류가 발생했습니다.' })
+    } finally {
+      setTogglingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* 매체 추가 폼 */}
+      <form onSubmit={handleAdd} className="space-y-4 rounded-2xl border border-slate-800 p-5">
+        <p className="text-sm font-semibold text-slate-200">새 매체 등록</p>
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <input
+            type="text"
+            placeholder="매체명 (예: 연합인포맥스)"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            className="flex-1 rounded-xl border border-slate-700 bg-slate-900 px-4 py-2.5 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-500 focus:outline-none"
+          />
+          <input
+            type="url"
+            placeholder="RSS URL (https://...)"
+            value={rssUrl}
+            onChange={(e) => setRssUrl(e.target.value)}
+            required
+            className="flex-[2] rounded-xl border border-slate-700 bg-slate-900 px-4 py-2.5 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-500 focus:outline-none"
+          />
+          <button
+            type="submit"
+            disabled={adding}
+            className="rounded-xl bg-sky-700 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-sky-600 disabled:opacity-60"
+          >
+            {adding ? '등록 중...' : '등록'}
+          </button>
+        </div>
+        {message && (
+          <p
+            className={[
+              'rounded-lg px-4 py-2 text-sm',
+              message.kind === 'ok'
+                ? 'bg-emerald-950/50 text-emerald-200'
+                : 'bg-rose-950/50 text-rose-200',
+            ].join(' ')}
+          >
+            {message.text}
+          </p>
+        )}
+      </form>
+
+      {/* 매체 목록 */}
+      {sources.length === 0 ? (
+        <p className="text-sm text-slate-400">등록된 매체가 없습니다.</p>
+      ) : (
+        <div className="overflow-hidden rounded-2xl border border-slate-800">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-900/60">
+              <tr>
+                <th className="px-4 py-3 text-left font-semibold text-slate-300">매체명</th>
+                <th className="px-4 py-3 text-left font-semibold text-slate-300">RSS URL</th>
+                <th className="px-4 py-3 text-left font-semibold text-slate-300">등록일</th>
+                <th className="px-4 py-3 text-center font-semibold text-slate-300">상태</th>
+                <th className="px-4 py-3 text-center font-semibold text-slate-300">활성화</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800">
+              {sources.map((source) => (
+                <tr key={source.id} className="text-slate-200 hover:bg-slate-800/30">
+                  <td className="px-4 py-3 font-medium">{source.name}</td>
+                  <td className="max-w-xs truncate px-4 py-3 text-slate-400">
+                    <a
+                      href={source.rssUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hover:text-sky-300 hover:underline"
+                    >
+                      {source.rssUrl}
+                    </a>
+                  </td>
+                  <td className="px-4 py-3 text-slate-400">
+                    {new Date(source.createdAt).toLocaleDateString('ko-KR')}
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <span
+                      className={[
+                        'rounded-full px-2.5 py-0.5 text-xs font-medium',
+                        source.active
+                          ? 'bg-emerald-950/50 text-emerald-200'
+                          : 'bg-slate-800 text-slate-400',
+                      ].join(' ')}
+                    >
+                      {source.active ? '활성' : '비활성'}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <button
+                      type="button"
+                      disabled={togglingId === source.id}
+                      onClick={() => handleToggle(source)}
+                      className={[
+                        'rounded-lg px-3 py-1.5 text-xs font-medium transition disabled:opacity-60',
+                        source.active
+                          ? 'bg-rose-950/50 text-rose-200 hover:bg-rose-900/50'
+                          : 'bg-emerald-950/50 text-emerald-200 hover:bg-emerald-900/50',
+                      ].join(' ')}
+                    >
+                      {togglingId === source.id
+                        ? '처리 중...'
+                        : source.active
+                          ? '비활성화'
+                          : '활성화'}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/admin/sources.ts
+++ b/src/lib/admin/sources.ts
@@ -1,0 +1,134 @@
+// Admin 매체(media_sources) 데이터 접근 함수
+// Server Components와 API Route Handler 양쪽에서 재사용
+
+import { createAdminClient } from '@/lib/supabase/admin'
+
+// ── 애플리케이션 레이어 타입 ───────────────────────────────────────────────
+
+export type AdminMediaSource = {
+  id: string
+  name: string
+  rssUrl: string
+  active: boolean
+  createdAt: string
+}
+
+// ── 에러 클래스 ──────────────────────────────────────────────────────────
+
+export class SourceNotFoundError extends Error {
+  constructor(id: string) {
+    super(`media source not found: ${id}`)
+    this.name = 'SourceNotFoundError'
+  }
+}
+
+export class SourceDuplicateError extends Error {
+  constructor(rssUrl: string) {
+    super(`media source already exists: ${rssUrl}`)
+    this.name = 'SourceDuplicateError'
+  }
+}
+
+// ── 데이터 접근 함수 ──────────────────────────────────────────────────────
+
+/**
+ * 매체 목록 조회 — 등록 순서 기준, 전체 반환
+ */
+export async function getAdminSources(): Promise<AdminMediaSource[]> {
+  const client = createAdminClient()
+
+  const { data, error } = await client
+    .from('media_sources')
+    .select('id, name, rss_url, active, created_at')
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    throw new Error(`media_sources 조회 실패: ${error.message}`)
+  }
+
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    name: row.name,
+    rssUrl: row.rss_url,
+    active: row.active,
+    createdAt: row.created_at,
+  }))
+}
+
+/**
+ * 매체 등록
+ * @throws SourceDuplicateError — 동일한 rss_url이 이미 존재할 때
+ */
+export async function createSource(params: {
+  name: string
+  rssUrl: string
+}): Promise<AdminMediaSource> {
+  const client = createAdminClient()
+
+  // 중복 확인
+  const { data: existing, error: checkError } = await client
+    .from('media_sources')
+    .select('id')
+    .eq('rss_url', params.rssUrl)
+    .maybeSingle()
+
+  if (checkError) {
+    throw new Error(`중복 확인 실패: ${checkError.message}`)
+  }
+
+  if (existing) {
+    throw new SourceDuplicateError(params.rssUrl)
+  }
+
+  const { data, error } = await client
+    .from('media_sources')
+    .insert({ name: params.name, rss_url: params.rssUrl })
+    .select('id, name, rss_url, active, created_at')
+    .single()
+
+  if (error) {
+    throw new Error(`media_sources 등록 실패: ${error.message}`)
+  }
+
+  return {
+    id: data.id,
+    name: data.name,
+    rssUrl: data.rss_url,
+    active: data.active,
+    createdAt: data.created_at,
+  }
+}
+
+/**
+ * 매체 활성/비활성 토글 (PATCH)
+ * @throws SourceNotFoundError — 해당 id의 매체가 없을 때
+ */
+export async function toggleSourceActive(
+  id: string,
+  active: boolean,
+): Promise<AdminMediaSource> {
+  const client = createAdminClient()
+
+  const { data, error } = await client
+    .from('media_sources')
+    .update({ active })
+    .eq('id', id)
+    .select('id, name, rss_url, active, created_at')
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(`media_sources 업데이트 실패: ${error.message}`)
+  }
+
+  if (!data) {
+    throw new SourceNotFoundError(id)
+  }
+
+  return {
+    id: data.id,
+    name: data.name,
+    rssUrl: data.rss_url,
+    active: data.active,
+    createdAt: data.created_at,
+  }
+}


### PR DESCRIPTION
## Summary

- `src/lib/admin/sources.ts`: `media_sources` 테이블 CRUD 데이터 접근 함수 구현 (`getAdminSources`, `createSource`, `toggleSourceActive`)
- `src/app/api/admin/sources/route.ts`: GET(목록 조회), POST(매체 등록) API 구현 — Zod 유효성 검증 및 중복 RSS URL 409 처리 포함
- `src/app/api/admin/sources/[id]/route.ts`: PATCH(활성/비활성 토글) API 구현
- `src/components/features/admin/SourcesManager.tsx`: 매체 등록 폼 + 목록 테이블 클라이언트 컴포넌트 (낙관적 UI 업데이트)
- `src/app/(admin)/admin/sources/page.tsx`: 서버 컴포넌트 페이지 완성 (기존 TODO 스텁 대체)

기존 `media_sources` DB 테이블과 마이그레이션은 이미 존재하므로 별도 마이그레이션 불필요.

## Test plan

- [ ] `/admin/sources` 페이지에서 매체 목록이 정상 로드되는지 확인
- [ ] 새 매체명 + RSS URL 입력 후 등록 시 목록에 즉시 반영되는지 확인
- [ ] 중복 RSS URL 등록 시 오류 메시지 표시 확인
- [ ] 활성 매체 "비활성화" 버튼 클릭 시 상태 토글 확인
- [ ] 비활성 매체 "활성화" 버튼 클릭 시 상태 토글 확인
- [ ] 인증 없이 API 호출 시 401 반환 확인
- [ ] `npm run build` 통과 확인