### PR TITLE
[Issue #30] 릴리즈 체크리스트 실행 — 코드 검증 및 보고

### DIFF
--- a/src/components/features/feed/FeedView.tsx
+++ b/src/components/features/feed/FeedView.tsx
@@ -178,7 +178,18 @@ export default function FeedView({ date, issues, initialIssueId, previousDate }:
                 <p className="mt-4 line-clamp-3 text-sm leading-6 text-slate-200">{item.summary}</p>
                 <div className="mt-4 flex flex-wrap items-center gap-2">
                   {item.source ? (
-                    <FeedSourceLink source={item.source} />
+                    <FeedSourceLink
+                      source={item.source}
+                      onClick={() =>
+                        trackFeedEvent({
+                          event: 'source_clicked',
+                          entityType: item.entityType,
+                          entityId: item.entityId,
+                          url: item.source!.url,
+                          isLoggedIn: false,
+                        })
+                      }
+                    />
                   ) : (
                     <span className="rounded-full border border-dashed border-white/15 px-3 py-2 text-xs text-white/60">
                       출처 확인 후 업데이트


### PR DESCRIPTION
## 개요

Issue #30 릴리즈 체크리스트의 코드 검증 가능 항목을 전수 점검하고, 발견된 코드 갭 1건을 수정합니다.

---

## 섹션 1 — 사전 조건

| 항목 | 결과 |
|------|------|
| 최신 PRD 기준 범위 동결 확인 | ⚠️ 인간 확인 필요 |
| 최신 디자인/기능 문서 반영 확인 | ⚠️ 인간 확인 필요 |
| 웹 배포 환경 접근 권한 및 설정 점검 | ⚠️ 인간 확인 필요 |

---

## 섹션 2 — 핵심 기능 점검

### 2.1 발행/피드

| 항목 | 결과 | 근거 |
|------|------|------|
| 장 마감 후 당일 카드 뉴스 정상 발행 | ⚠️ 인간 확인 필요 | 파이프라인/Cron 존재 확인, 실행 결과는 운영 로그로 확인 필요 |
| 세로 스크롤(그룹)·가로 스와이프(카드) 동작 | ✅ | `FeedCardStack.tsx`: touch 이벤트(`handleTouchStart`/`handleTouchEnd`) + 버튼 네비게이션 구현 |
| 카드 진행 상태(1/N) 정확히 표시 | ✅ | `FeedCardStack.tsx` L215: `{activeIndex + 1}/{totalCards}` 렌더링 + progressbar role 설정 |
| 핵심 카드에 변동 사실(수치/방향)·변동 이유 노출 | ✅ | `generate.ts`: cover 카드 `sub` 필드에 수치 요약 강제, reason 카드 타입 명시. 시스템 프롬프트에 "수치 없는 cover 금지" 규칙 포함 |
| 코스피/나스닥/USD-KRW 맥락 카드 노출 | ✅ | `FeedView.tsx` L24-27: `CONTEXT_SLOTS` 상수로 3개 슬롯 고정 렌더링 |

### 2.2 공유/비로그인

| 항목 | 결과 | 근거 |
|------|------|------|
| 이슈 permalink 생성 | ✅ | `FeedView.tsx` L248: `${origin}/feed/${date}/issue/${issue.id}` 형식으로 permalink 생성 |
| 공유 링크 비로그인 열람 | ✅ | `middleware.ts`: `/admin` 경로만 인증 적용. `/feed/*` 경로는 인증 없이 접근 가능 |
| 링크 미리보기(썸네일/제목/요약) 정상 노출 | ✅ | `app/(public)/feed/[date]/issue/[id]/page.tsx`: `generateMetadata()`에서 `openGraph.images: [{ url: /api/og/issue/${id} }]` 설정. `/api/og/issue/[id]/route.ts`에서 ImageResponse(1200x630) 동적 생성 |

### 2.3 출처/고지

| 항목 | 결과 | 근거 |
|------|------|------|
| 카드별 출처 링크 누락 없이 포함 | ✅ | `generate.ts` 시스템 프롬프트: reason/bullish/bearish 카드의 `sources` 최소 1개 필수. 마지막 source 카드 필수 |
| 출처 링크 실제로 열림 | ⚠️ 인간 확인 필요 | `FeedSourceLink.tsx`: URL 유효성 검증(`isSafeExternalUrl`) 후 `target="_blank"` 링크 렌더링. 실제 URL 동작은 실행 환경에서 확인 필요 |
| 투자 자문 오해 방지 문구 노출 | ✅ | `FeedDisclaimer.tsx`: "본 콘텐츠는 투자 자문이 아닌 정보 제공 목적입니다." `(public)/layout.tsx`에서 모든 공개 라우트(피드·공유 링크 랜딩 포함)에 렌더링 |

---

## 섹션 3 — 웹 정합성/품질 점검

| 항목 | 결과 | 근거 |
|------|------|------|
| 모바일 가독성(폰트/간격/터치 영역) | ✅ | `FeedShareButton.tsx` L81: `min-h-11`(44px). `FeedSourceLink.tsx` L33: `min-h-11`. `FeedCardStack.tsx` L262/L272: 이전/다음 카드 버튼 `min-h-11`. 터치 영역 44px 확보 |
| 데스크톱 핵심 열람 동선 유지 | ✅ | `(public)/layout.tsx`: `max-w-[960px]`로 데스크톱 최대 폭 제한. `FeedView.tsx`: `sm:flex-row`, `lg:grid-cols-3` 반응형 레이아웃 |
| 로딩/빈 화면/오류 화면 준비 | ✅ | 로딩: `feed/[date]/loading.tsx`, `feed/[date]/issue/[id]/loading.tsx`. 빈 화면: `FeedEmptyState.tsx`. 오류: `FeedErrorState.tsx` + `(public)/error.tsx` |
| 공유 링크 최초 진입 체감 지연 | ⚠️ 인간 확인 필요 | ISR/캐싱 설정 및 실제 TTFB는 Vercel 배포 환경에서 확인 필요 |

---

## 섹션 4 — 계측/운영 점검

| 항목 | 결과 | 근거 |
|------|------|------|
| `feed_opened` 이벤트 수집 | ✅ | `FeedView.tsx` L80-88: `useEffect`에서 `trackFeedEvent({ event: 'feed_opened', ... })` 호출 |
| `card_swiped` 이벤트 수집 | ✅ | `FeedCardStack.tsx` L158-165: `moveCard()` 내에서 인덱스 변경 시 `trackFeedEvent({ event: 'card_swiped', ... })` 호출 |
| `share_clicked` 이벤트 수집 | ✅ | `FeedShareButton.tsx` L38-44: 공유 버튼 클릭 시 `trackFeedEvent({ event: 'share_clicked', ... })` 호출 |
| `source_clicked` 이벤트 수집 | 🔧 수정됨 | `FeedCardStack.tsx`는 기존 구현 완료. 맥락 카드 섹션(`FeedView.tsx`)의 `FeedSourceLink`에는 `onClick`이 누락되어 있었음 → 이번 PR에서 수정 |
| 오류 로그 수집/조회 경로 준비 | ✅ | `(public)/error.tsx` L15: `useEffect(() => { console.error(error) })`. `/api/events/route.ts`: `console.info('[feed-event]', payload)`. Vercel 대시보드에서 조회 가능 |
| 운영 문의/이슈 대응 담당자 확인 | ⚠️ 인간 확인 필요 | — |

---

## 섹션 5 — 2인 파일럿 점검

⚠️ 인간 확인 필요 — 모바일 선호 사용자 1명, 데스크톱 선호 사용자 1명 대상 파일럿 검증이 필요합니다.

---

## 섹션 6 — Go/No-Go

⚠️ 인간 확인 필요 — 섹션 5 파일럿 결과를 반영하여 최종 결정이 필요합니다.

---

## 수정 내역

### 🔧 `src/components/features/feed/FeedView.tsx`

코스피/나스닥/USD-KRW 맥락 카드 섹션의 `FeedSourceLink`에 `source_clicked` 이벤트 핸들러를 추가합니다.

**변경 전**: 맥락 카드 출처 링크 클릭 시 이벤트가 발행되지 않음  
**변경 후**: `entityType`, `entityId`, `url` 포함 `source_clicked` 이벤트 발행

---

## 빌드 결과

- `npx tsc --noEmit`: ✅ 오류 없음
- `npm run lint`: ✅ 오류 없음
- `npx next build` (stub 환경변수): ✅ 성공