### PR TITLE
security: 5개 테이블 RLS 활성화 및 공개 읽기 정책 추가

### DIFF
--- a/supabase/migrations/20260326000000_enable_rls.sql
+++ b/supabase/migrations/20260326000000_enable_rls.sql
@@ -1,0 +1,51 @@
+-- ============================================================
+-- RLS 활성화 및 공개 읽기 정책 설정
+-- Date: 2026-03-26
+-- Tables: feeds, issues, tags, issue_tags, media_sources
+-- Notes:
+--   - Admin/Pipeline은 service_role 클라이언트를 사용하므로 RLS 우회
+--   - 공개 API(anon)는 published/approved 데이터만 읽을 수 있음
+--   - media_sources는 공개 접근 불필요 → 정책 없이 RLS만 활성화
+-- ============================================================
+
+-- ── RLS 활성화 ──────────────────────────────────────────────────────────────
+
+ALTER TABLE feeds         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE issues        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tags          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE issue_tags    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE media_sources ENABLE ROW LEVEL SECURITY;
+
+-- ── feeds: published 피드만 공개 읽기 ────────────────────────────────────────
+
+CREATE POLICY "feeds_public_read"
+  ON feeds
+  FOR SELECT
+  TO anon
+  USING (status = 'published');
+
+-- ── issues: approved 이슈만 공개 읽기 ────────────────────────────────────────
+
+CREATE POLICY "issues_public_read"
+  ON issues
+  FOR SELECT
+  TO anon
+  USING (status = 'approved');
+
+-- ── tags: 전체 공개 읽기 ──────────────────────────────────────────────────────
+
+CREATE POLICY "tags_public_read"
+  ON tags
+  FOR SELECT
+  TO anon
+  USING (true);
+
+-- ── issue_tags: 전체 공개 읽기 ────────────────────────────────────────────────
+
+CREATE POLICY "issue_tags_public_read"
+  ON issue_tags
+  FOR SELECT
+  TO anon
+  USING (true);
+
+-- media_sources: 정책 없음 → anon 접근 차단 (admin only via service_role)


### PR DESCRIPTION
## 변경 이유
Supabase 보안 경고(`rls_disabled_in_public`) 대응. `public.feeds`, `issues`, `issue_tags`, `tags`, `media_sources` 5개 테이블에 RLS가 비활성화되어 있어 PostgREST를 통한 무단 접근이 가능한 상태였음.

## 변경 범위
`supabase/migrations/20260326000000_enable_rls.sql` 추가

| 테이블 | RLS | anon 정책 |
|--------|-----|-----------|
| `feeds` | 활성화 | `status = 'published'` 인 행만 SELECT |
| `issues` | 활성화 | `status = 'approved'` 인 행만 SELECT |
| `tags` | 활성화 | 전체 SELECT |
| `issue_tags` | 활성화 | 전체 SELECT |
| `media_sources` | 활성화 | 정책 없음 (anon 차단) |

Admin/Pipeline은 `service_role` 키를 사용하므로 RLS 자동 우회 — 기존 동작 영향 없음.

## 검증
- Supabase Dashboard SQL Editor에서 직접 실행 완료, 보안 경고 해소 확인
- `npm run build` 통과

## 남은 작업 / 리스크
없음