### PR TITLE
fix: 파이프라인 LLM 출력 잘림으로 인한 JSON 파싱 실패 수정

### DIFF
--- a/src/lib/pipeline/generate.ts
+++ b/src/lib/pipeline/generate.ts
@@ -18,7 +18,7 @@ const SONNET_OUTPUT_COST_PER_TOKEN = 15.0 / 1_000_000
 
 const MAX_ISSUES = 3
 
-const DEFAULT_MODEL = 'claude-sonnet-4-5-20250929'
+const DEFAULT_MODEL = 'claude-sonnet-4-6'
 const GENERATE_TOOL_NAME = 'generate_cards'
 
 const generatedIssueSchema = z.object({
@@ -38,6 +38,7 @@ const generatedIssuesResponseSchema = z.object({
 type AnthropicClientLike = {
   messages: {
     create: (params: Record<string, unknown>) => Promise<{
+      stop_reason: string | null
       content: Array<{
         type: string
         name?: string
@@ -441,13 +442,22 @@ function getAnthropicClient() {
   })
 }
 
-function extractToolInput(message: {
-  content: Array<{
-    type: string
-    name?: string
-    input?: unknown
-  }>
-}) {
+function extractToolInput(
+  message: {
+    stop_reason: string | null
+    content: Array<{
+      type: string
+      name?: string
+      input?: unknown
+    }>
+  },
+) {
+  if (message.stop_reason === 'max_tokens') {
+    throw new Error(
+      'LLM 출력이 max_tokens 한도에 도달해 잘렸습니다. 출력 토큰 한도를 늘리거나 요청을 줄이세요.',
+    )
+  }
+
   const toolUse = message.content.find(
     (block) => block.type === 'tool_use' && block.name === GENERATE_TOOL_NAME,
   )
@@ -463,6 +473,7 @@ function extractToolInput(message: {
     try {
       input.issues = JSON.parse(input.issues)
     } catch {
+      console.error('[generate] issues 파싱 실패. raw:', (input.issues as string).slice(0, 200))
       throw new Error('issues 필드가 유효하지 않은 JSON 문자열입니다.')
     }
   }
@@ -490,7 +501,7 @@ export async function generateIssues(
   const anthropic = deps.anthropic ?? getAnthropicClient()
   const response = await anthropic.messages.create({
     model: process.env.ANTHROPIC_MODEL ?? DEFAULT_MODEL,
-    max_tokens: 8192,
+    max_tokens: 16000,
     temperature: 0.7,
     system: buildSystemPrompt(),
     messages: [
@@ -563,7 +574,7 @@ export async function generateContextIssues(
   const anthropic = deps.anthropic ?? getAnthropicClient()
   const response = await anthropic.messages.create({
     model: process.env.ANTHROPIC_MODEL ?? DEFAULT_MODEL,
-    max_tokens: 8192,
+    max_tokens: 16000,
     temperature: 0.7,
     system: buildSystemPrompt(),
     messages: [


### PR DESCRIPTION
## 문제

운영 환경 파이프라인 수동 실행 시 `issues 필드가 유효하지 않은 JSON 문자열입니다.` 에러로 실패.

**근본 원인**: 30개 기사 + 긴 시스템 프롬프트로 인해 LLM 응답이 `max_tokens: 8192` 한도에 걸려 JSON이 잘렸고, 잘린 JSON 문자열은 파싱 불가능.

## 수정 사항

- `DEFAULT_MODEL`: `claude-sonnet-4-5-20250929` → `claude-sonnet-4-6`
- `max_tokens`: `8192` → `16000`
- `stop_reason === 'max_tokens'` 체크 추가 — 한도 초과 시 명확한 에러 메시지
- 파싱 실패 시 raw string 앞 200자 `console.error` 로깅 (디버깅용)

## 검증

로컬에서 수동 실행 성공 확인.