### PR TITLE
fix: 어드민 피드 목록에 draft 피드 미표시 버그 수정

### DIFF
--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,6 +1,8 @@
 import { FeedList } from '@/components/features/admin/FeedList'
 import { getAdminFeeds } from '@/lib/admin/feeds'
 
+export const dynamic = 'force-dynamic'
+
 export default async function AdminPage() {
   try {
     const feeds = await getAdminFeeds()


### PR DESCRIPTION
## 문제

크론잡으로 생성된 draft 피드(2026-04-01, 04-02)가 `/admin` 피드 목록에 표시되지 않음.

## 원인

`/admin` 페이지가 `force-dynamic` 선언 없이 Next.js App Router Server Component로 구성되어 있어, Vercel 배포 시 빌드 타임에 정적 렌더링됨. 이후 생성된 피드는 재배포 전까지 목록에 반영되지 않음.

## 수정

`export const dynamic = 'force-dynamic'` 추가 — 매 요청마다 Supabase에서 최신 피드 목록을 조회하도록 변경.

## 영향 범위

`src/app/(admin)/admin/page.tsx` 1줄 추가. 어드민 전용 페이지이므로 공개 피드에 영향 없음.