### PR TITLE
fix: RSS 수집 User-Agent를 브라우저 UA로 교체해 403 차단 해소

### DIFF
--- a/src/lib/pipeline/collect.ts
+++ b/src/lib/pipeline/collect.ts
@@ -11,6 +11,9 @@ import type {
 
 const RSS_TIMEOUT_MS = 30_000
 
+const BROWSER_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+
 type ParserLike = Pick<Parser, 'parseURL'>
 
 function getKstDateString(date: Date) {
@@ -103,7 +106,9 @@ export async function collectArticles(
     new Parser({
       timeout: RSS_TIMEOUT_MS,
       headers: {
-        'user-agent': 'findori-pipeline/1.0',
+        'User-Agent': BROWSER_USER_AGENT,
+        Accept: 'application/rss+xml, application/xml, text/xml, */*',
+        'Accept-Language': 'ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7',
       },
     })
 
@@ -120,10 +125,8 @@ export async function collectArticles(
           .filter((article): article is CollectedArticle => article !== null)
           .filter((article) => isSameTargetDate(article.publishedAt, targetDate))
       } catch (error) {
-        errors.push({
-          source: source.name,
-          message: error instanceof Error ? error.message : 'unknown_error',
-        })
+        const message = error instanceof Error ? error.message : 'unknown_error'
+        errors.push({ source: source.name, message })
         return []
       }
     }),


### PR DESCRIPTION
## 변경 이유
한국경제 RSS 서버가 `findori-pipeline/1.0` User-Agent를 크롤러로 판단해 HTTP 403 차단 오류가 2026-03-31 이후 3일 연속 발생, 파이프라인이 partial 상태로 머물러 있었습니다.

## 변경 범위
- `src/lib/pipeline/collect.ts`: rss-parser 기본 헤더를 브라우저 UA(Chrome/124)로 교체
- `User-Agent`, `Accept`, `Accept-Language` 헤더를 브라우저 표준값으로 설정

## 검증
- `npm run type-check` 통과
- `npm run lint` 통과
- `npm run build` 성공

## 남은 작업 / 리스크
- 브라우저 UA 교체 후에도 403이 지속될 경우 해당 소스를 `active = false`로 비활성화 필요

Related #118