### PR TITLE
fix: 전체 버튼에 cursor-pointer 적용

### DIFF
--- a/src/app/(admin)/admin/login/AdminLoginForm.tsx
+++ b/src/app/(admin)/admin/login/AdminLoginForm.tsx
@@ -85,7 +85,7 @@ export default function AdminLoginForm({ nextPath, statusMessage }: AdminLoginFo
             disabled={isSubmitting || password.length === 0}
             className={cn(
               'w-full rounded-lg px-4 py-3 text-sm font-semibold',
-              'bg-white text-slate-950 disabled:cursor-not-allowed disabled:opacity-50',
+              'cursor-pointer bg-white text-slate-950 disabled:cursor-not-allowed disabled:opacity-50',
             )}
           >
             {isSubmitting ? '로그인 중...' : '로그인'}

--- a/src/app/(public)/error.tsx
+++ b/src/app/(public)/error.tsx
@@ -34,7 +34,7 @@ export default function PublicError({ error, reset }: ErrorProps) {
       <div className="flex flex-wrap justify-center gap-3">
         <button
           onClick={reset}
-          className="bg-accent-blue text-foreground rounded-lg px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+          className="bg-accent-blue text-foreground cursor-pointer rounded-lg px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           다시 시도
         </button>
@@ -46,7 +46,7 @@ export default function PublicError({ error, reset }: ErrorProps) {
         </Link>
         <button
           onClick={handleCopyLink}
-          className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+          className="bg-surface text-foreground hover:bg-surface-raised cursor-pointer rounded-lg px-5 py-2.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           {copied ? '복사됨!' : '링크 복사'}
         </button>

--- a/src/components/features/admin/AdminNav.tsx
+++ b/src/components/features/admin/AdminNav.tsx
@@ -67,7 +67,7 @@ export function AdminNav() {
             type="button"
             onClick={handleLogout}
             disabled={pending}
-            className="rounded-full bg-rose-950/70 px-3 py-2 text-sm text-rose-100 transition hover:bg-rose-900 disabled:opacity-60"
+            className="cursor-pointer rounded-full bg-rose-950/70 px-3 py-2 text-sm text-rose-100 transition hover:bg-rose-900 disabled:cursor-not-allowed disabled:opacity-60"
           >
             {pending ? '로그아웃 중...' : '로그아웃'}
           </button>

--- a/src/components/features/admin/CardEditForm.tsx
+++ b/src/components/features/admin/CardEditForm.tsx
@@ -168,7 +168,7 @@ export function CardEditForm({
           type="button"
           onClick={onCancel}
           disabled={disabled}
-          className="rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-300 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+          className="cursor-pointer rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-300 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
         >
           취소
         </button>
@@ -176,7 +176,7 @@ export function CardEditForm({
           type="button"
           onClick={onSave}
           disabled={disabled || validationError !== null}
-          className="rounded-lg bg-sky-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-50"
+          className="cursor-pointer rounded-lg bg-sky-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {disabled ? '저장 중...' : '저장'}
         </button>

--- a/src/components/features/admin/IssueListItem.tsx
+++ b/src/components/features/admin/IssueListItem.tsx
@@ -219,7 +219,7 @@ export function IssueListItem({ issue }: IssueListItemProps) {
         <button
           type="button"
           onClick={() => setOpen((value) => !value)}
-          className="min-w-0 flex-1 text-left"
+          className="min-w-0 flex-1 cursor-pointer text-left"
         >
           <div className="space-y-2">
             <div className="flex items-center gap-3">
@@ -268,7 +268,7 @@ export function IssueListItem({ issue }: IssueListItemProps) {
                     type="button"
                     onClick={handleOrderSave}
                     disabled={isSavingCard}
-                    className="rounded-lg bg-sky-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="cursor-pointer rounded-lg bg-sky-600 px-3 py-2 text-sm font-semibold text-white transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     순서 저장
                   </button>
@@ -315,7 +315,7 @@ export function IssueListItem({ issue }: IssueListItemProps) {
                             type="button"
                             onClick={() => moveCard(index, -1)}
                             disabled={!canMoveUp || isSavingCard}
-                            className="rounded-lg border border-slate-700 px-2 py-1 text-sm text-slate-300 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+                            className="cursor-pointer rounded-lg border border-slate-700 px-2 py-1 text-sm text-slate-300 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
                             aria-label={`${card.type} 카드를 위로 이동`}
                           >
                             ↑
@@ -324,7 +324,7 @@ export function IssueListItem({ issue }: IssueListItemProps) {
                             type="button"
                             onClick={() => moveCard(index, 1)}
                             disabled={!canMoveDown || isSavingCard}
-                            className="rounded-lg border border-slate-700 px-2 py-1 text-sm text-slate-300 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+                            className="cursor-pointer rounded-lg border border-slate-700 px-2 py-1 text-sm text-slate-300 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
                             aria-label={`${card.type} 카드를 아래로 이동`}
                           >
                             ↓
@@ -333,7 +333,7 @@ export function IssueListItem({ issue }: IssueListItemProps) {
                             type="button"
                             onClick={() => startEditing(card)}
                             disabled={isSavingCard}
-                            className="rounded-lg border border-slate-700 px-3 py-1.5 text-sm text-slate-200 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+                            className="cursor-pointer rounded-lg border border-slate-700 px-3 py-1.5 text-sm text-slate-200 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
                           >
                             편집
                           </button>

--- a/src/components/features/admin/IssueStatusActions.tsx
+++ b/src/components/features/admin/IssueStatusActions.tsx
@@ -8,7 +8,7 @@ type IssueStatusActionsProps = {
 
 function getButtonClassName(active: boolean, palette: 'slate' | 'emerald' | 'rose') {
   const base =
-    'rounded-lg px-3 py-1.5 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-50'
+    'cursor-pointer rounded-lg px-3 py-1.5 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-50'
 
   if (palette === 'emerald') {
     return `${base} ${active ? 'bg-emerald-500 text-white' : 'bg-emerald-600 text-white hover:bg-emerald-500'}`

--- a/src/components/features/admin/PipelineManager.tsx
+++ b/src/components/features/admin/PipelineManager.tsx
@@ -85,7 +85,7 @@ export function PipelineManager({ initialLogs, initialTotal }: Props) {
           type="button"
           onClick={handleRun}
           disabled={running}
-          className="rounded-xl bg-sky-700 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-sky-600 disabled:opacity-60"
+          className="cursor-pointer rounded-xl bg-sky-700 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-sky-600 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {running ? '실행 중...' : '수동 재실행'}
         </button>

--- a/src/components/features/admin/PublishFeedButton.tsx
+++ b/src/components/features/admin/PublishFeedButton.tsx
@@ -79,7 +79,7 @@ export function PublishFeedButton({ date, feedStatus }: PublishFeedButtonProps) 
         type="button"
         onClick={handlePublish}
         disabled={isLoading}
-        className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
+        className="cursor-pointer rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
       >
         {isLoading ? '발행 중...' : '피드 발행'}
       </button>

--- a/src/components/features/admin/SourcesManager.tsx
+++ b/src/components/features/admin/SourcesManager.tsx
@@ -104,7 +104,7 @@ export function SourcesManager({ initialSources }: Props) {
           <button
             type="submit"
             disabled={adding}
-            className="rounded-xl bg-sky-700 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-sky-600 disabled:opacity-60"
+            className="cursor-pointer rounded-xl bg-sky-700 px-5 py-2.5 text-sm font-medium text-white transition hover:bg-sky-600 disabled:cursor-not-allowed disabled:opacity-60"
           >
             {adding ? '등록 중...' : '등록'}
           </button>
@@ -173,7 +173,7 @@ export function SourcesManager({ initialSources }: Props) {
                       disabled={togglingId === source.id}
                       onClick={() => handleToggle(source)}
                       className={[
-                        'rounded-lg px-3 py-1.5 text-xs font-medium transition disabled:opacity-60',
+                        'cursor-pointer rounded-lg px-3 py-1.5 text-xs font-medium transition disabled:cursor-not-allowed disabled:opacity-60',
                         source.active
                           ? 'bg-rose-950/50 text-rose-200 hover:bg-rose-900/50'
                           : 'bg-emerald-950/50 text-emerald-200 hover:bg-emerald-900/50',

--- a/src/components/features/feed/FeedCardStack.tsx
+++ b/src/components/features/feed/FeedCardStack.tsx
@@ -527,7 +527,7 @@ export default function FeedCardStack({ cards, entityType, entityId }: FeedCardS
           type="button"
           onClick={() => moveCard('prev')}
           disabled={activeIndex === 0}
-          className="min-h-11 rounded-full border border-white/12 px-4 py-2 text-sm font-medium text-white/80 transition focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+          className="min-h-11 cursor-pointer rounded-full border border-white/12 px-4 py-2 text-sm font-medium text-white/80 transition focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
         >
           이전 카드
         </button>
@@ -538,7 +538,7 @@ export default function FeedCardStack({ cards, entityType, entityId }: FeedCardS
           type="button"
           onClick={() => moveCard('next')}
           disabled={activeIndex === totalCards - 1}
-          className="min-h-11 rounded-full border border-white/12 px-4 py-2 text-sm font-medium text-white/80 transition focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+          className="min-h-11 cursor-pointer rounded-full border border-white/12 px-4 py-2 text-sm font-medium text-white/80 transition focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
         >
           다음 카드
         </button>

--- a/src/components/features/feed/FeedEmptyState.tsx
+++ b/src/components/features/feed/FeedEmptyState.tsx
@@ -26,7 +26,7 @@ export default function FeedEmptyState({ date, previousDate }: FeedEmptyStatePro
       <div className="flex flex-wrap justify-center gap-3">
         <button
           onClick={() => window.location.reload()}
-          className="bg-accent-blue text-foreground rounded-lg px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+          className="bg-accent-blue text-foreground cursor-pointer rounded-lg px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           재시도
         </button>

--- a/src/components/features/feed/FeedErrorState.tsx
+++ b/src/components/features/feed/FeedErrorState.tsx
@@ -25,7 +25,7 @@ export default function FeedErrorState() {
       <div className="flex flex-wrap justify-center gap-3">
         <button
           onClick={() => window.location.reload()}
-          className="bg-accent-blue text-foreground rounded-lg px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+          className="bg-accent-blue text-foreground cursor-pointer rounded-lg px-5 py-2.5 text-sm font-medium transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           다시 시도
         </button>
@@ -37,7 +37,7 @@ export default function FeedErrorState() {
         </Link>
         <button
           onClick={handleCopyLink}
-          className="bg-surface text-foreground hover:bg-surface-raised rounded-lg px-5 py-2.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+          className="bg-surface text-foreground hover:bg-surface-raised cursor-pointer rounded-lg px-5 py-2.5 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
         >
           {copied ? '복사됨!' : '링크 복사'}
         </button>

--- a/src/components/features/feed/FeedShareButton.tsx
+++ b/src/components/features/feed/FeedShareButton.tsx
@@ -78,7 +78,7 @@ export default function FeedShareButton({
       <button
         type="button"
         onClick={handleShare}
-        className="min-h-11 rounded-full border border-white/12 px-4 py-2 text-sm font-medium text-white/80 transition hover:border-white/30 hover:text-white focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-1 focus-visible:outline-none"
+        className="min-h-11 cursor-pointer rounded-full border border-white/12 px-4 py-2 text-sm font-medium text-white/80 transition hover:border-white/30 hover:text-white focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-1 focus-visible:outline-none"
       >
         공유
       </button>


### PR DESCRIPTION
## 변경 이유

버튼 요소에 마우스를 올렸을 때 커서가 기본값(default)으로 표시되는 문제가 있었습니다. 특히 `/admin/pipeline`의 수동 실행 버튼이 대표적인 예시입니다. 사용자가 클릭 가능한 요소임을 시각적으로 인지할 수 있도록 커서를 포인터로 변경합니다.

## 변경 범위

admin 및 공개 피드 화면의 모든 `<button>` 요소에 `cursor-pointer` 클래스를 추가했습니다.

- `src/app/(admin)/admin/login/AdminLoginForm.tsx` — 로그인 버튼
- `src/app/(public)/error.tsx` — 다시 시도, 링크 복사 버튼
- `src/components/features/admin/AdminNav.tsx` — 로그아웃 버튼
- `src/components/features/admin/CardEditForm.tsx` — 취소, 저장 버튼
- `src/components/features/admin/IssueListItem.tsx` — 접기/펼치기, 순서 저장, 위/아래 이동, 편집 버튼
- `src/components/features/admin/IssueStatusActions.tsx` — 초안/승인/반려 버튼
- `src/components/features/admin/PipelineManager.tsx` — 수동 재실행 버튼
- `src/components/features/admin/PublishFeedButton.tsx` — 피드 발행 버튼
- `src/components/features/admin/SourcesManager.tsx` — 등록, 활성화/비활성화 버튼
- `src/components/features/feed/FeedCardStack.tsx` — 이전 카드/다음 카드 버튼
- `src/components/features/feed/FeedEmptyState.tsx` — 재시도 버튼
- `src/components/features/feed/FeedErrorState.tsx` — 다시 시도, 링크 복사 버튼
- `src/components/features/feed/FeedShareButton.tsx` — 공유 버튼

또한 기존에 `disabled:opacity-60`만 있고 `disabled:cursor-not-allowed`가 없던 버튼들에 누락된 클래스도 함께 추가했습니다.

## 검증

- `tsc --noEmit` 타입 검사 통과
- 컴파일(`next build` Compiled 단계) 정상 완료

## 남은 작업 / 리스크

없음.

Closes #94