### PR TITLE
캐싱 설정 추가: 공개 API 및 피드 페이지 ISR 적용

### DIFF
--- a/src/app/(public)/feed/[date]/issue/[id]/page.tsx
+++ b/src/app/(public)/feed/[date]/issue/[id]/page.tsx
@@ -10,6 +10,9 @@ import {
   isValidDate,
 } from '@/lib/public/feeds'
 
+// 이슈 상세 페이지도 10분 ISR (SNS 공유 링크의 메타데이터 포함)
+export const revalidate = 600
+
 type Params = Promise<{ date: string; id: string }>
 
 export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {

--- a/src/app/(public)/feed/[date]/page.tsx
+++ b/src/app/(public)/feed/[date]/page.tsx
@@ -6,6 +6,9 @@ import FeedErrorState from '@/components/features/feed/FeedErrorState'
 import FeedView from '@/components/features/feed/FeedView'
 import { getPreviousPublishedDate, getPublicFeedByDate, isValidDate } from '@/lib/public/feeds'
 
+// 피드 데이터는 하루 1회 발행되므로 10분 ISR로 Supabase 쿼리 절감
+export const revalidate = 600
+
 type Params = Promise<{ date: string }>
 
 export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {

--- a/src/app/api/feeds/[date]/route.ts
+++ b/src/app/api/feeds/[date]/route.ts
@@ -24,7 +24,13 @@ export async function GET(_request: Request, { params }: { params: Params }) {
       )
     }
 
-    return NextResponse.json({ date: result.feed.date, issues: result.issues }, { status: 200 })
+    // 과거 날짜 피드는 내용이 변경되지 않으므로 24시간 캐시
+    const response = NextResponse.json(
+      { date: result.feed.date, issues: result.issues },
+      { status: 200 },
+    )
+    response.headers.set('Cache-Control', 's-maxage=86400, stale-while-revalidate=604800')
+    return response
   } catch {
     return NextResponse.json({ error: 'internal_error' }, { status: 500 })
   }

--- a/src/app/api/feeds/latest/route.ts
+++ b/src/app/api/feeds/latest/route.ts
@@ -5,7 +5,9 @@ import { getLatestPublishedDate } from '@/lib/public/feeds'
 export async function GET() {
   try {
     const date = await getLatestPublishedDate()
-    return NextResponse.json({ date }, { status: 200 })
+    const response = NextResponse.json({ date }, { status: 200 })
+    response.headers.set('Cache-Control', 's-maxage=300, stale-while-revalidate=3600')
+    return response
   } catch {
     return NextResponse.json({ error: 'internal_error' }, { status: 500 })
   }

--- a/src/app/api/issues/[id]/route.ts
+++ b/src/app/api/issues/[id]/route.ts
@@ -17,7 +17,10 @@ export async function GET(_request: Request, { params }: { params: Params }) {
       )
     }
 
-    return NextResponse.json(issue, { status: 200 })
+    // 발행된 이슈는 내용이 변경되지 않으므로 24시간 캐시
+    const response = NextResponse.json(issue, { status: 200 })
+    response.headers.set('Cache-Control', 's-maxage=86400, stale-while-revalidate=604800')
+    return response
   } catch {
     return NextResponse.json({ error: 'internal_error' }, { status: 500 })
   }

--- a/src/app/api/og/issue/[id]/route.ts
+++ b/src/app/api/og/issue/[id]/route.ts
@@ -219,9 +219,13 @@ export async function GET(request: Request, { params }: { params: Params }) {
       ),
     )
 
+    // OG 이미지는 발행 후 변경되지 않으므로 24시간 캐시
     return new ImageResponse(tree, {
       width: 1200,
       height: 630,
+      headers: {
+        'Cache-Control': 's-maxage=86400, stale-while-revalidate=604800',
+      },
     })
   } catch {
     return NextResponse.redirect(new URL('/og-default.png', request.url))


### PR DESCRIPTION
## 변경 이유

공개 피드 API와 페이지가 요청마다 Supabase를 쿼리하고 있어 불필요한 DB 부하와 Vercel 함수 실행 비용이 발생하고 있었습니다. 발행된 피드/이슈 데이터는 내용이 바뀌지 않으므로 Vercel CDN 캐싱과 Next.js ISR을 통해 비용을 절감하고 응답 속도를 개선합니다.

## 변경 범위

**API 라우트 - HTTP Cache-Control 헤더 추가**

| 경로 | 캐싱 전략 | 이유 |
|---|---|---|
| `/api/feeds/[date]` | `s-maxage=86400, swr=604800` | 발행된 과거 피드는 내용 불변 |
| `/api/feeds/latest` | `s-maxage=300, swr=3600` | 최신 날짜 포인터, 파이프라인 실행 주기(1일) 고려해 5분 캐시 |
| `/api/issues/[id]` | `s-maxage=86400, swr=604800` | 발행된 이슈는 내용 불변 |
| `/api/og/issue/[id]` | `s-maxage=86400, swr=604800` | OG 이미지는 SNS 공유 후 변경 없음 |

**페이지 - Next.js ISR revalidate 설정**

- `/feed/[date]`: `revalidate = 600` (10분)
- `/feed/[date]/issue/[id]`: `revalidate = 600` (10분)

Admin API 경로(`/api/admin/*`)는 실시간 데이터가 필요하므로 캐싱 미적용.

## 검증

- `npx tsc --noEmit`: 타입 에러 없음
- `npm run build`: 빌드 성공, 모든 라우트 컴파일 통과

## 남은 작업 / 리스크

- 피드 발행 후 최대 5분간 `/api/feeds/latest`가 이전 날짜를 반환할 수 있으나 허용 범위 내 (운영팀이 즉시 확인하는 경우 하드 리프레시로 해소 가능)
- ISR 10분 설정은 보수적 수치이며, 운영 중 트래픽 패턴 확인 후 조정 가능

Closes #110