### PR TITLE
feat: 소스 연속 실패 시 어드민 파이프라인 페이지에 경고 배너 표시

### DIFF
--- a/src/app/(admin)/admin/pipeline/page.tsx
+++ b/src/app/(admin)/admin/pipeline/page.tsx
@@ -1,4 +1,6 @@
+import { SourceFailureAlertBanner } from '@/components/features/admin/SourceFailureAlert'
 import { PipelineManager } from '@/components/features/admin/PipelineManager'
+import { detectSourceFailures } from '@/lib/admin/pipeline-alerts'
 import { listPipelineLogs } from '@/lib/pipeline'
 import { createAdminClient } from '@/lib/supabase/admin'
 
@@ -9,6 +11,8 @@ export default async function AdminPipelinePage() {
     const client = createAdminClient()
     const { logs, total } = await listPipelineLogs(client, { page: 1, limit: 20 })
 
+    const sourceAlerts = detectSourceFailures(logs)
+
     return (
       <section className="space-y-6">
         <div className="space-y-2">
@@ -18,6 +22,7 @@ export default async function AdminPipelinePage() {
             파이프라인 실행 이력을 확인하고 수동으로 재실행합니다.
           </p>
         </div>
+        <SourceFailureAlertBanner alerts={sourceAlerts} />
         <PipelineManager initialLogs={logs} initialTotal={total} />
       </section>
     )

--- a/src/components/features/admin/SourceFailureAlert.tsx
+++ b/src/components/features/admin/SourceFailureAlert.tsx
@@ -1,0 +1,48 @@
+import type { SourceFailureAlert } from '@/lib/admin/pipeline-alerts'
+
+type Props = {
+  alerts: SourceFailureAlert[]
+}
+
+export function SourceFailureAlertBanner({ alerts }: Props) {
+  if (alerts.length === 0) return null
+
+  return (
+    <div className="rounded-2xl border border-amber-800/50 bg-amber-950/40 px-5 py-4">
+      <div className="flex items-start gap-3">
+        <svg
+          className="mt-0.5 h-5 w-5 shrink-0 text-amber-400"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fillRule="evenodd"
+            d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
+            clipRule="evenodd"
+          />
+        </svg>
+        <div className="space-y-1.5">
+          <p className="text-sm font-semibold text-amber-200">
+            소스 연속 실패 감지 — {alerts.length}개 소스
+          </p>
+          <ul className="space-y-1">
+            {alerts.map((alert) => (
+              <li key={alert.sourceName} className="text-sm text-amber-300">
+                <span className="font-medium">{alert.sourceName}</span>
+                <span className="text-amber-400/80">
+                  {' '}
+                  — {alert.consecutiveFailures}일 연속 오류
+                </span>
+              </li>
+            ))}
+          </ul>
+          <p className="text-xs text-amber-500">
+            RSS 수집 오류가 2일 이상 지속되고 있습니다. 소스 URL 또는 피드 상태를 확인하세요.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/admin/pipeline-alerts.ts
+++ b/src/lib/admin/pipeline-alerts.ts
@@ -1,0 +1,75 @@
+// 파이프라인 소스 연속 실패 감지 로직
+// pipeline_logs.errors 컬럼을 파싱해 소스별 연속 실패 여부를 계산한다.
+
+import type { Json } from '@/types/database.types'
+import type { PipelineError } from '@/types/pipeline'
+
+export type SourceFailureAlert = {
+  sourceName: string
+  consecutiveFailures: number
+}
+
+const CONSECUTIVE_FAILURE_THRESHOLD = 2
+
+/**
+ * JSON 타입의 errors 컬럼을 PipelineError[] 로 안전하게 파싱한다.
+ */
+function parseErrors(errors: Json): PipelineError[] {
+  if (!Array.isArray(errors)) return []
+  return errors.filter(
+    (e): e is PipelineError =>
+      typeof e === 'object' &&
+      e !== null &&
+      typeof (e as Record<string, unknown>).source === 'string' &&
+      typeof (e as Record<string, unknown>).message === 'string',
+  )
+}
+
+/**
+ * 최근 N개의 파이프라인 로그에서 소스별 연속 실패 횟수를 계산한다.
+ *
+ * - 로그는 최신순(내림차순)으로 정렬되어 있어야 한다.
+ * - 동일 소스에 대해 가장 최근 로그부터 연속으로 오류가 있을 때 카운트한다.
+ * - 한 번이라도 오류가 없으면 연속 횟수를 초기화한다.
+ * - CONSECUTIVE_FAILURE_THRESHOLD 이상이면 경고로 반환한다.
+ */
+export function detectSourceFailures(
+  logs: Array<{ errors: Json; status: string }>,
+): SourceFailureAlert[] {
+  // 소스별 연속 실패 횟수 추적
+  // null = 아직 성공 기록 없음(카운팅 중), number = 연속 실패 횟수
+  const consecutiveCount: Map<string, number> = new Map()
+  // 소스별로 연속 체인이 끊겼는지 여부
+  const chainBroken: Set<string> = new Set()
+
+  for (const log of logs) {
+    const errors = parseErrors(log.errors)
+    // 이번 로그에서 오류가 발생한 소스 집합
+    const failedSources = new Set(errors.map((e) => e.source))
+
+    // 이번 로그에서 오류가 발생하지 않은 소스는 연속 체인 끊김
+    // (단, 체인이 이미 끊긴 소스는 무시)
+    for (const [source] of consecutiveCount) {
+      if (!chainBroken.has(source) && !failedSources.has(source)) {
+        chainBroken.add(source)
+      }
+    }
+
+    // 이번 로그에서 오류가 있는 소스 카운트
+    for (const source of failedSources) {
+      if (chainBroken.has(source)) continue
+      consecutiveCount.set(source, (consecutiveCount.get(source) ?? 0) + 1)
+    }
+  }
+
+  const alerts: SourceFailureAlert[] = []
+  for (const [sourceName, count] of consecutiveCount) {
+    if (!chainBroken.has(sourceName) && count >= CONSECUTIVE_FAILURE_THRESHOLD) {
+      alerts.push({ sourceName, consecutiveFailures: count })
+    }
+  }
+
+  // 연속 실패 횟수 내림차순 정렬
+  alerts.sort((a, b) => b.consecutiveFailures - a.consecutiveFailures)
+  return alerts
+}


### PR DESCRIPTION
## 변경 이유

파이프라인 소스 오류는 `pipeline_logs.errors` 컬럼에만 기록되며 어드민 UI에 별도 경고가 없었습니다. 동일 소스에서 RSS 수집 실패가 며칠째 지속되어도 어드민이 인지하기 어려운 문제를 해결합니다.

## 변경 범위

- `src/lib/admin/pipeline-alerts.ts` (신규): `pipeline_logs.errors` 컬럼을 파싱해 소스별 연속 실패 횟수를 계산하는 `detectSourceFailures()` 함수. 임계값 2일 이상 연속 실패 시 경고 반환.
- `src/components/features/admin/SourceFailureAlert.tsx` (신규): amber 경고 배너 컴포넌트. 경고가 없으면 null을 반환해 불필요한 공간을 차지하지 않음.
- `src/app/(admin)/admin/pipeline/page.tsx` (수정): 페이지 로드 시 최근 20개 로그를 분석해 경고 배너를 렌더링.

## 검증

- `npx tsc --noEmit` 타입 검사 통과
- `npm run build` 프로덕션 빌드 성공

## 남은 작업 / 리스크

- 임계값(2일)은 상수(`CONSECUTIVE_FAILURE_THRESHOLD`)로 분리되어 있어 추후 변경 용이
- 소스 이름은 `pipeline_logs.errors[].source` 값 그대로 표시 (source_name 매핑 없음)

Closes #119