### PR TITLE
feat: 미발행 draft 피드 강조 표시 (어드민)

### DIFF
--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,3 +1,4 @@
+import { DraftFeedAlert } from '@/components/features/admin/DraftFeedAlert'
 import { FeedList } from '@/components/features/admin/FeedList'
 import { getAdminFeeds } from '@/lib/admin/feeds'
 
@@ -16,6 +17,7 @@ export default async function AdminPage() {
             최신 피드부터 확인하고 날짜별 이슈 검토 화면으로 이동합니다.
           </p>
         </div>
+        <DraftFeedAlert feeds={feeds} />
         <FeedList feeds={feeds} />
       </section>
     )

--- a/src/components/features/admin/DraftFeedAlert.tsx
+++ b/src/components/features/admin/DraftFeedAlert.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link'
+
+import type { AdminFeedSummary } from '@/lib/admin/feeds'
+
+type Props = {
+  feeds: AdminFeedSummary[]
+}
+
+/**
+ * 1일 이상 지난 미발행(draft) 피드가 있을 때 상단에 표시하는 경고 배너.
+ * 가장 오래된 미발행 피드로 바로 이동하는 CTA 버튼을 포함한다.
+ */
+export function DraftFeedAlert({ feeds }: Props) {
+  const overdueFeeds = feeds.filter((f) => f.isOverdue)
+
+  if (overdueFeeds.length === 0) return null
+
+  // 오름차순 정렬 후 가장 오래된 항목
+  const oldest = [...overdueFeeds].sort((a, b) => a.date.localeCompare(b.date))[0]
+
+  return (
+    <div className="rounded-2xl border border-rose-800/50 bg-rose-950/40 px-5 py-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <svg
+            className="mt-0.5 h-5 w-5 shrink-0 text-rose-400"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fillRule="evenodd"
+              d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
+              clipRule="evenodd"
+            />
+          </svg>
+          <div className="space-y-1">
+            <p className="text-sm font-semibold text-rose-200">
+              미발행 draft 피드 {overdueFeeds.length}건
+            </p>
+            <p className="text-xs text-rose-400">
+              1일 이상 지난 미발행 피드가 있습니다. 검토 후 발행해주세요.
+            </p>
+          </div>
+        </div>
+        <Link
+          href={`/admin/feed/${oldest.date}`}
+          className="shrink-0 rounded-lg bg-rose-700/60 px-3 py-1.5 text-xs font-medium text-rose-100 transition hover:bg-rose-700/80"
+        >
+          가장 오래된 피드 검토 ({oldest.date})
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/components/features/admin/FeedListItem.tsx
+++ b/src/components/features/admin/FeedListItem.tsx
@@ -21,22 +21,38 @@ function formatPublishedAt(value: string | null): string {
 }
 
 export function FeedListItem({ feed }: FeedListItemProps) {
+  const isOverdue = feed.isOverdue
+
   return (
     <li>
       <Link
         href={`/admin/feed/${feed.date}`}
-        className="bg-surface-raised border-border flex items-center justify-between gap-4 rounded-2xl border px-5 py-4 transition hover:border-slate-500 hover:bg-slate-700/60"
+        className={[
+          'flex items-center justify-between gap-4 rounded-2xl border px-5 py-4 transition',
+          isOverdue
+            ? 'border-rose-800/60 bg-rose-950/30 hover:border-rose-700/70 hover:bg-rose-950/50'
+            : 'bg-surface-raised border-border hover:border-slate-500 hover:bg-slate-700/60',
+        ].join(' ')}
       >
         <div className="space-y-2">
           <div className="flex items-center gap-3">
-            <span className="text-lg font-semibold text-slate-50">{feed.date}</span>
+            <span className={['text-lg font-semibold', isOverdue ? 'text-rose-200' : 'text-slate-50'].join(' ')}>
+              {feed.date}
+            </span>
             <StatusBadge status={feed.status} />
+            {isOverdue && (
+              <span className="rounded-full bg-rose-900/60 px-2 py-0.5 text-xs font-medium text-rose-300">
+                미발행
+              </span>
+            )}
           </div>
-          <p className="text-sm text-slate-300">
+          <p className={['text-sm', isOverdue ? 'text-rose-300/80' : 'text-slate-300'].join(' ')}>
             이슈 {feed.issueCount}건 · {formatPublishedAt(feed.publishedAt)}
           </p>
         </div>
-        <span className="text-sm font-medium text-slate-400">검토 보기</span>
+        <span className={['text-sm font-medium', isOverdue ? 'text-rose-400' : 'text-slate-400'].join(' ')}>
+          검토 보기
+        </span>
       </Link>
     </li>
   )

--- a/src/lib/admin/feeds.ts
+++ b/src/lib/admin/feeds.ts
@@ -61,6 +61,7 @@ export type AdminFeedSummary = {
   status: 'draft' | 'published'
   publishedAt: string | null // ISO 8601
   issueCount: number
+  isOverdue: boolean // 오늘 기준 1일 이상 지난 draft 피드
 }
 
 export type AdminIssueSummary = {
@@ -124,10 +125,24 @@ export async function getAdminFeeds(): Promise<AdminFeedSummary[]> {
     return []
   }
 
+  // 오늘 날짜 (KST 기준 YYYY-MM-DD)
+  const todayKST = new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+    .format(new Date())
+    .replace(/\. /g, '-')
+    .replace('.', '')
+
   return rows.map((row) => {
     // Supabase 집계: issues(count) → [{ count: N }] 형태
     const countRow = row.issues?.[0]
     const issueCount = countRow?.count ?? 0
+
+    // 오늘 기준 1일 이상 지난 draft 피드 감지
+    const isOverdue = row.status === 'draft' && row.date < todayKST
 
     return {
       id: row.id,
@@ -135,6 +150,7 @@ export async function getAdminFeeds(): Promise<AdminFeedSummary[]> {
       status: row.status,
       publishedAt: row.published_at,
       issueCount,
+      isOverdue,
     }
   })
 }
@@ -181,12 +197,23 @@ export async function getAdminFeedByDate(date: string): Promise<{
   const issueRows = (issuesData ?? []) as IssueRow[]
   const issueCount = issueRows.length
 
+  const todayKSTForDetail = new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+    .format(new Date())
+    .replace(/\. /g, '-')
+    .replace('.', '')
+
   const feed: AdminFeedSummary = {
     id: feedRow.id,
     date: feedRow.date,
     status: feedRow.status,
     publishedAt: feedRow.published_at,
     issueCount,
+    isOverdue: feedRow.status === 'draft' && feedRow.date < todayKSTForDetail,
   }
 
   const issues: AdminIssueSummary[] = issueRows.map((row) => {

--- a/tests/unit/lib/admin-feeds.test.ts
+++ b/tests/unit/lib/admin-feeds.test.ts
@@ -117,6 +117,7 @@ describe('getAdminFeeds', () => {
       status: 'draft',
       publishedAt: null,
       issueCount: 5,
+      isOverdue: true,
     })
     expect(result[1]).toEqual<AdminFeedSummary>({
       id: 'feed-2',
@@ -124,6 +125,7 @@ describe('getAdminFeeds', () => {
       status: 'published',
       publishedAt: '2026-03-02T14:00:00Z',
       issueCount: 3,
+      isOverdue: false,
     })
   })
 
@@ -207,6 +209,7 @@ describe('getAdminFeedByDate', () => {
       status: 'draft',
       publishedAt: null,
       issueCount: 1,
+      isOverdue: true,
     })
 
     expect(result.issues).toHaveLength(1)


### PR DESCRIPTION
## 변경 이유

파이프라인이 매일 draft 피드를 생성하지만, 오래된 미발행 피드에 대한 별도 강조가 없어 운영자가 발행 지연을 인지하지 못할 수 있습니다.

## 변경 범위

- `src/lib/admin/feeds.ts`: `AdminFeedSummary` 타입에 `isOverdue` 필드 추가. 오늘(KST) 기준 1일 이상 지난 draft 피드에 `true` 반환. `getAdminFeeds`, `getAdminFeedByDate` 양쪽에 적용
- `src/components/features/admin/DraftFeedAlert.tsx` (신규): 미발행 draft 피드 수 표시 배너. 가장 오래된 피드로 바로 이동하는 CTA 버튼 포함
- `src/components/features/admin/FeedListItem.tsx`: `isOverdue` 피드에 rose 계열 강조 스타일 및 "미발행" 뱃지 적용
- `src/app/(admin)/admin/page.tsx`: `DraftFeedAlert` 배너를 피드 목록 상단에 추가
- `tests/unit/lib/admin-feeds.test.ts`: `isOverdue` 필드를 기존 테스트 fixture에 반영

## 검증

- `npx tsc --noEmit` 타입 오류 없음
- `npm run lint` 린트 오류 없음

## 남은 작업 / 리스크

- 없음. 오늘 날짜 계산은 서버 사이드(KST 기준)에서 수행하므로 클라이언트 시간대 차이 영향 없음

Closes #120