### PR TITLE
fix: 피드 이슈 간 구분 강화 — 프로그레스바 제거 + 캡션 구분선 추가

### DIFF
--- a/src/components/features/feed/FeedCardStack.tsx
+++ b/src/components/features/feed/FeedCardStack.tsx
@@ -24,7 +24,6 @@ const BODY_TEXT_CLASS =
 const HEADING_TEXT_CLASS =
   'leading-tight font-semibold break-keep whitespace-pre-line md:text-[1.65rem] xl:text-[1.8rem]'
 
-const LABEL_TEXT_CLASS = 'text-[11px] font-medium tracking-[0.14em] text-white/70 uppercase'
 
 function cardStyle(visual: CardVisual, imageUrl: string | null): CSSProperties {
   const gradient = `linear-gradient(160deg, ${visual.bg_from}f2, ${visual.bg_via}d9, ${visual.bg_to})`
@@ -368,7 +367,6 @@ export default function FeedCardStack({ cards, entityType, entityId }: FeedCardS
 
   const totalCards = cards?.length ?? 0
   const activeCard = cards?.[activeIndex] ?? null
-  const progress = ((activeIndex + 1) / totalCards) * 100
   const activeImageUrl = useMemo(
     () => (activeCard ? resolveImageUrl(activeCard.visual.imgCategory) : null),
     [activeCard],
@@ -460,26 +458,7 @@ export default function FeedCardStack({ cards, entityType, entityId }: FeedCardS
   }
 
   return (
-    <div className="space-y-4">
-      <div className="space-y-3">
-        <div className="flex items-center justify-between gap-3">
-          <p className="text-muted text-xs font-medium">{progressLabel(activeIndex, totalCards)}</p>
-          <p className={LABEL_TEXT_CLASS}>{activeCard.type}</p>
-        </div>
-        <div
-          aria-hidden="true"
-          className="h-1.5 overflow-hidden rounded-full bg-white/10"
-          role="progressbar"
-          aria-valuemin={1}
-          aria-valuemax={totalCards}
-          aria-valuenow={activeIndex + 1}
-        >
-          <div
-            className="h-full rounded-full bg-white/80 transition-[width] duration-200 ease-out"
-            style={{ width: `${progress}%` }}
-          />
-        </div>
-      </div>
+    <div className="space-y-3">
       <div
         data-testid="feed-card-swipe"
         onTouchStart={handleTouchStart}
@@ -531,7 +510,7 @@ export default function FeedCardStack({ cards, entityType, entityId }: FeedCardS
         >
           이전 카드
         </button>
-        <p className="text-muted text-xs" aria-live="polite">
+        <p className="text-muted text-xs" aria-live="polite" aria-atomic="true">
           {progressLabel(activeIndex, totalCards)}
         </p>
         <button

--- a/src/components/features/feed/FeedView.tsx
+++ b/src/components/features/feed/FeedView.tsx
@@ -151,9 +151,9 @@ export default function FeedView({ date, issues, initialIssueId, previousDate }:
           </div>
         </div>
       </header>
-      <main className="flex flex-1 flex-col items-center gap-12 px-4 py-6 sm:gap-16 sm:px-6">
+      <main className="flex flex-1 flex-col items-center gap-0 px-4 py-6 sm:px-6">
         {contextIssues.length > 0 ? (
-          <section className="rounded-[32px] border border-white/10 bg-[linear-gradient(160deg,rgba(15,23,42,0.96),rgba(17,24,39,0.92),rgba(3,7,18,0.98))] p-5 shadow-[0_18px_40px_rgba(2,6,23,0.24)]">
+          <section className="w-full max-w-2xl rounded-[32px] border border-white/10 bg-[linear-gradient(160deg,rgba(15,23,42,0.96),rgba(17,24,39,0.92),rgba(3,7,18,0.98))] p-5 shadow-[0_18px_40px_rgba(2,6,23,0.24)]">
             <div className="flex flex-col gap-2">
               <p className="text-[11px] font-semibold tracking-[0.22em] text-cyan-200 uppercase">
                 Market Context
@@ -220,7 +220,7 @@ export default function FeedView({ date, issues, initialIssueId, previousDate }:
             key={issue.id}
             id={`issue-${issue.id}`}
             data-issue-id={issue.id}
-            className="w-full max-w-2xl"
+            className="w-full max-w-2xl pt-10 sm:pt-14"
           >
             <div
               className={[
@@ -238,7 +238,7 @@ export default function FeedView({ date, issues, initialIssueId, previousDate }:
                 entityId={issue.entityId}
               />
             </div>
-            <div className="mt-3 flex items-start justify-between gap-3 px-1">
+            <div className="mt-3 flex items-start justify-between gap-3 border-b border-white/8 px-1 pb-10 sm:pb-14">
               <div className="min-w-0 flex-1">
                 <p className="text-muted text-xs sm:text-sm">{issue.entityName}</p>
                 <h2 className="text-foreground mt-1 text-sm leading-snug font-medium break-keep sm:text-base">


### PR DESCRIPTION
- FeedCardStack 상단 진행률 영역(카운터·카드타입라벨·프로그레스바) 제거
  - 카드 face 내부 i/n 카운터와 3중 중복 해소
  - 프로그레스바가 이슈 구분선처럼 보이던 시각적 혼란 제거
- FeedView 캡션 하단에 얇은 구분선(border-b border-white/8) + 여백 추가
  - 이슈 간 시각적 경계 명확화
- 미사용 상수(LABEL_TEXT_CLASS, progress) 제거