### PR TITLE
chore: 파이프라인 크론잡 임시 비활성화

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "crons": [
-    {
-      "path": "/api/cron/pipeline",
-      "schedule": "0 13 * * *"
-    }
-  ]
+  "crons": []
 }


### PR DESCRIPTION
## 변경 내용

`vercel.json`의 `crons` 배열을 비워 파이프라인 자동 실행을 임시 중단합니다.

## 원래 스케줄 (재개 시 복원)

```
json
"crons": [
  {
    "path": "/api/cron/pipeline",
    "schedule": "0 13 * * *"
  }
]
```

- 경로: `/api/cron/pipeline`
- 스케줄: 매일 UTC 13:00 (KST 22:00)

## 재개 방법

위 설정을 `vercel.json`에 다시 추가하고 main에 머지하면 즉시 재개됩니다.